### PR TITLE
Set the roborio compiler to be optional by default

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
@@ -30,7 +30,7 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
         Property<Boolean> optional = project.getObjects().property(Boolean.class);
-        optional.set(false);
+        optional.set(true);
 
         ToolchainDescriptor<RoboRioGcc> descriptor = new ToolchainDescriptor<>(toolchainName, "roborioGcc", new ToolchainRegistrar<RoboRioGcc>(RoboRioGcc.class, project), optional);
         descriptor.setToolchainPlatforms(NativePlatforms.roborio);


### PR DESCRIPTION
This should be something enforced by GradleRIO, not native utils by default