### PR TITLE
Enable support for fully stripping shared binaries with private symbols

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/OrderedStripTask.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/OrderedStripTask.java
@@ -1,0 +1,96 @@
+package edu.wpi.first.toolchain;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.nativeplatform.NativeBinarySpec;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
+
+import jaci.gradle.log.ETLogger;
+import jaci.gradle.log.ETLoggerFactory;
+
+public class OrderedStripTask implements Action<Task> {
+
+    public final ToolchainExtension tcExt;
+    public final NativeBinarySpec binary;
+    public final AbstractLinkTask linkTask;
+    public final GccToolChain gcc;
+    public final Project project;
+    private boolean performStripAll = false;
+    private boolean performDebugStrip = false;
+
+
+    public boolean getPerformStripAll() {
+        return performStripAll;
+    }
+
+    public void setPerformStripAll(boolean stripAll) {
+        performStripAll = stripAll;
+    }
+
+    public boolean getPerformDebugStrip() {
+        return performDebugStrip;
+    }
+
+    public void setPerformDebugStrip(boolean stripDebug) {
+        performDebugStrip = stripDebug;
+    }
+
+
+    public OrderedStripTask(ToolchainExtension tcExt, NativeBinarySpec binary, AbstractLinkTask linkTask, GccToolChain gcc, Project project) {
+        this.tcExt = tcExt;
+        this.binary = binary;
+        this.linkTask = linkTask;
+        this.project = project;
+        this.gcc = gcc;
+    }
+
+    @Override
+    public void execute(Task task) {
+        if (!performDebugStrip) return;
+        List<String> excludeComponents = tcExt
+                .getStripExcludeComponentsForPlatform(binary.getTargetPlatform().getName());
+        if (excludeComponents != null && excludeComponents.contains(binary.getComponent().getName())) {
+            return;
+        }
+
+        File mainFile = linkTask.getLinkedFile().get().getAsFile();
+
+        if (mainFile.exists()) {
+            String mainFileStr = mainFile.toString();
+            String debugFile = mainFileStr + ".debug";
+
+            ToolchainDiscoverer disc = gcc.getDiscoverer();
+
+            Optional<File> objcopyOptional = disc.tool("objcopy");
+            Optional<File> stripOptional = disc.tool("strip");
+            if (!objcopyOptional.isPresent() || !stripOptional.isPresent()) {
+                ETLogger logger = ETLoggerFactory.INSTANCE.create("NativeBinaryStrip");
+                logger.logError("Failed to strip binaries because of unknown tool objcopy and strip");
+                return;
+            }
+
+            String objcopy = disc.tool("objcopy").get().toString();
+            String strip = disc.tool("strip").get().toString();
+
+            project.exec((ex) -> {
+                ex.commandLine(objcopy, "--only-keep-debug", mainFileStr, debugFile);
+            });
+            project.exec((ex) -> {
+                ex.commandLine(strip, "-g", mainFileStr);
+            });
+            project.exec((ex) -> {
+                ex.commandLine(objcopy, "--add-gnu-debuglink=" + debugFile, mainFileStr);
+            });
+            if (performStripAll) {
+                project.exec((ex) -> {
+                    ex.commandLine(strip, "--strip-all", "--discard-all", mainFileStr);
+                });   
+            }
+        }
+    }
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -10,6 +10,7 @@ import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.internal.logging.text.DiagnosticsVisitor;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 
 import edu.wpi.first.toolchain.bionic.BionicToolchainPlugin;
 import edu.wpi.first.toolchain.configurable.ConfigurableGcc;
@@ -24,6 +25,8 @@ public class ToolchainExtension {
     private final NamedDomainObjectContainer<CrossCompilerConfiguration> crossCompilers;
     private final NamedDomainObjectContainer<ToolchainDescriptorBase> toolchainDescriptors;
     private final Map<String, List<String>> stripExcludeMap = new HashMap<>();
+
+    private final Map<AbstractLinkTask, OrderedStripTask> linkTaskMap = new HashMap<>();
 
     private Project project;
 
@@ -60,6 +63,10 @@ public class ToolchainExtension {
             }
         });
 
+    }
+
+    public Map<AbstractLinkTask, OrderedStripTask> getLinkTaskMap() {
+        return linkTaskMap;
     }
 
     public void setSinglePrintPerPlatform() {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ compileGroovy {
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2020.5.0"
+    version = "2020.5.1"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/configs/PrivateExportsConfig.java
+++ b/src/main/java/edu/wpi/first/nativeutils/configs/PrivateExportsConfig.java
@@ -2,7 +2,9 @@ package edu.wpi.first.nativeutils.configs;
 
 import org.gradle.api.Named;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.provider.Property;
 
 public interface PrivateExportsConfig extends Named {
   RegularFileProperty getExportsFile();
+  Property<Boolean> getPerformStripAllSymbols();
 }

--- a/src/main/java/edu/wpi/first/nativeutils/configs/impl/DefaultPrivateExportsConfig.java
+++ b/src/main/java/edu/wpi/first/nativeutils/configs/impl/DefaultPrivateExportsConfig.java
@@ -4,17 +4,21 @@ import javax.inject.Inject;
 
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
 
 import edu.wpi.first.nativeutils.configs.PrivateExportsConfig;
 
 public class DefaultPrivateExportsConfig implements PrivateExportsConfig {
-  private RegularFileProperty exportsFile;
+  private final RegularFileProperty exportsFile;
+  private final Property<Boolean> performStripAllSymbols;
 
   private String name;
 
   @Inject
   public DefaultPrivateExportsConfig(String name, ObjectFactory factory) {
     exportsFile = factory.fileProperty();
+    performStripAllSymbols = factory.property(Boolean.class);
+    performStripAllSymbols.set(false);
     this.name = name;
   }
 
@@ -26,5 +30,10 @@ public class DefaultPrivateExportsConfig implements PrivateExportsConfig {
   @Override
   public RegularFileProperty getExportsFile() {
     return exportsFile;
+  }
+
+  @Override
+  public Property<Boolean> getPerformStripAllSymbols() {
+    return performStripAllSymbols;
   }
 }

--- a/src/main/java/edu/wpi/first/nativeutils/rules/PrivateExportsConfigRules.java
+++ b/src/main/java/edu/wpi/first/nativeutils/rules/PrivateExportsConfigRules.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.nativeutils.rules;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import org.gradle.api.NamedDomainObjectCollection;
 import org.gradle.api.Project;
@@ -13,6 +14,7 @@ import org.gradle.model.Mutate;
 import org.gradle.model.RuleSource;
 import org.gradle.nativeplatform.NativeLibrarySpec;
 import org.gradle.nativeplatform.SharedLibraryBinarySpec;
+import org.gradle.nativeplatform.tasks.AbstractLinkTask;
 import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
 import org.gradle.platform.base.BinarySpec;
 import org.gradle.platform.base.ComponentSpec;
@@ -21,6 +23,9 @@ import org.gradle.platform.base.ComponentSpecContainer;
 import edu.wpi.first.nativeutils.NativeUtilsExtension;
 import edu.wpi.first.nativeutils.configs.PrivateExportsConfig;
 import edu.wpi.first.nativeutils.tasks.PrivateExportsGenerationTask;
+import edu.wpi.first.toolchain.GccToolChain;
+import edu.wpi.first.toolchain.OrderedStripTask;
+import edu.wpi.first.toolchain.ToolchainExtension;
 
 public class PrivateExportsConfigRules extends RuleSource {
 
@@ -35,6 +40,7 @@ public class PrivateExportsConfigRules extends RuleSource {
     }
 
     Project project = (Project) projectLayout.getProjectIdentifier();
+    final ToolchainExtension tcExt = extensions.getByType(ToolchainExtension.class);
 
     for (ComponentSpec component : components) {
       PrivateExportsConfig config = exports.findByName(component.getName());
@@ -51,39 +57,65 @@ public class PrivateExportsConfigRules extends RuleSource {
         }
         SharedLibraryBinarySpec binary = (SharedLibraryBinarySpec) oBinary;
         String exportsTaskName = "generateExports" + binary.getBuildTask().getName();
-        TaskProvider<PrivateExportsGenerationTask> exportsTask = project.getTasks().register(exportsTaskName, PrivateExportsGenerationTask.class, task -> {
-          task.getSymbolsToExportFile().set(config.getExportsFile());
-          task.getLibraryName().set(nativeComponent.getBaseName());
+        TaskProvider<PrivateExportsGenerationTask> exportsTask = project.getTasks().register(exportsTaskName,
+            PrivateExportsGenerationTask.class, task -> {
+              task.getSymbolsToExportFile().set(config.getExportsFile());
+              task.getLibraryName().set(nativeComponent.getBaseName());
 
+              if (binary.getTargetPlatform().getOperatingSystem().isWindows()) {
+                task.setIsWindows(true);
+                String exportsName = "exports.def";
+                task.getExportsFile().set(task.getProject()
+                    .file(task.getProject().getBuildDir() + "/tmp/" + task.getName() + "/" + exportsName));
+                ((LinkSharedLibrary) binary.getTasks().getLink()).getLinkerArgs().add(project.provider(() -> {
+                  return "/DEF:" + task.getExportsFile().get().getAsFile().toString();
+                }));
+                binary.getTasks().getLink().getInputs().file(task.getExportsFile());
+              } else if (binary.getTargetPlatform().getOperatingSystem().isMacOsX()) {
+                task.setIsMac(true);
+                String exportsName = "exports.txt";
+                task.getExportsFile().set(task.getProject()
+                    .file(task.getProject().getBuildDir() + "/tmp/" + task.getName() + "/" + exportsName));
+                ((LinkSharedLibrary) binary.getTasks().getLink()).getLinkerArgs().addAll(project.provider(() -> {
+                  return Arrays.asList("-exported_symbols_list", task.getExportsFile().get().getAsFile().toString());
+                }));
+                binary.getTasks().getLink().getInputs().file(task.getExportsFile());
+              } else {
+                String exportsName = "exports.txt";
+                task.getExportsFile().set(task.getProject()
+                    .file(task.getProject().getBuildDir() + "/tmp/" + task.getName() + "/" + exportsName));
+                ((LinkSharedLibrary) binary.getTasks().getLink()).getLinkerArgs().add(project.provider(() -> {
+                  return "-Wl,--version-script=" + task.getExportsFile().get().getAsFile().toString();
+                }));
+                binary.getTasks().getLink().getInputs().file(task.getExportsFile());
+              }
 
+            });
 
-          if (binary.getTargetPlatform().getOperatingSystem().isWindows()) {
-            task.setIsWindows(true);
-            String exportsName = "exports.def";
-            task.getExportsFile().set(task.getProject().file(task.getProject().getBuildDir() + "/tmp/" + task.getName() + "/" + exportsName));
-            ((LinkSharedLibrary)binary.getTasks().getLink()).getLinkerArgs().add(project.provider(() -> {
-              return "/DEF:" + task.getExportsFile().get().getAsFile().toString();
-            }));
-            binary.getTasks().getLink().getInputs().file(task.getExportsFile());
-          } else if (binary.getTargetPlatform().getOperatingSystem().isMacOsX()) {
-            task.setIsMac(true);
-            String exportsName = "exports.txt";
-            task.getExportsFile().set(task.getProject().file(task.getProject().getBuildDir() + "/tmp/" + task.getName() + "/" + exportsName));
-            ((LinkSharedLibrary)binary.getTasks().getLink()).getLinkerArgs().addAll(project.provider(() -> {
-              return Arrays.asList("-exported_symbols_list", task.getExportsFile().get().getAsFile().toString());
-            }));
-            binary.getTasks().getLink().getInputs().file(task.getExportsFile());
-          } else {
-            String exportsName = "exports.txt";
-            task.getExportsFile().set(task.getProject().file(task.getProject().getBuildDir() + "/tmp/" + task.getName() + "/" + exportsName));
-            ((LinkSharedLibrary)binary.getTasks().getLink()).getLinkerArgs().add(project.provider(() -> {
-              return "-Wl,--version-script=" + task.getExportsFile().get().getAsFile().toString();
-            }));
-            binary.getTasks().getLink().getInputs().file(task.getExportsFile());
+        Task rawLinkTask = binary.getTasks().getLink();
+        rawLinkTask.dependsOn(exportsTask);
+
+        if (config.getPerformStripAllSymbols().get()) {
+          if (rawLinkTask instanceof AbstractLinkTask) {
+            AbstractLinkTask linkTask = (AbstractLinkTask) rawLinkTask;
+            Map<AbstractLinkTask, OrderedStripTask> linkTaskMap = tcExt.getLinkTaskMap();
+            OrderedStripTask stripTask = linkTaskMap.get(linkTask);
+            if (stripTask == null) {
+
+              GccToolChain gcc = null;
+              if (binary.getToolChain() instanceof GccToolChain) {
+                gcc = (GccToolChain) binary.getToolChain();
+                stripTask = new OrderedStripTask(tcExt, binary, linkTask, gcc, project);
+                linkTaskMap.put(linkTask, stripTask);
+                linkTask.doLast(stripTask);
+              }
+            }
+
+            if (stripTask != null) {
+              stripTask.setPerformStripAll(true);
+            }
           }
-
-        });
-        binary.getTasks().getLink().dependsOn(exportsTask);
+        }
       }
     }
   }


### PR DESCRIPTION
This will run "--strip-all --discard-all" on private symbol binaries with the flag set. Reduces footprint of libraries.