### PR TITLE
Add -Wno-error=c11-extensions to macOS compiler

### DIFF
--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -62,7 +62,8 @@ public class WPINativeUtilsExtension {
         public List<String> macCompilerArgs = Collections
                 .unmodifiableList(Arrays.asList("-std=c++17", "-pedantic", "-fPIC", "-Wno-unused-parameter",
                         "-Wno-error=deprecated-declarations", "-Wno-missing-field-initializers",
-                        "-Wno-unused-private-field", "-Wno-unused-const-variable", "-pthread"));
+                        "-Wno-unused-private-field", "-Wno-unused-const-variable", "-Wno-error=c11-extensions",
+                        "-pthread"));
         public List<String> macCCompilerArgs = Collections.unmodifiableList(Arrays.asList("-pedantic", "-fPIC",
                 "-Wno-unused-parameter", "-Wno-missing-field-initializers", "-Wno-unused-private-field"));
         public List<String> macObjCppCompilerArgs = Collections


### PR DESCRIPTION
On AppleClang 12 (with macOS 11.0), including WPILib-OpenCV headers causes the build to fail. Example scan here: https://gradle.com/s/4bndkaxghnipk

This flag also works on macOS 10.15 Catalina. CI build for that here: https://github.com/prateekma/allwpilib/runs/1027361880?check_suite_focus=true