### PR TITLE
Fix static link order

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ compileGroovy {
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2022.0.0"
+    version = "2022.0.1"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -524,8 +524,8 @@ public class WPINativeUtilsExtension {
                     deps.add("wpilibc_static");
                     deps.add("ntcore_static");
                     deps.add("hal_static");
-                    deps.add("wpiutil_static");
                     deps.add("wpimath_static");
+                    deps.add("wpiutil_static");
                     deps.add("chipobject_shared");
                     deps.add("netcomm_shared");
                     deps.add("visa_shared");
@@ -537,8 +537,8 @@ public class WPINativeUtilsExtension {
                     deps.add("wpilibc_static");
                     deps.add("ntcore_static");
                     deps.add("hal_static");
-                    deps.add("wpiutil_static");
                     deps.add("wpimath_static");
+                    deps.add("wpiutil_static");
                     deps.add("chipobject_shared");
                     deps.add("netcomm_shared");
                     deps.add("visa_shared");
@@ -650,8 +650,8 @@ public class WPINativeUtilsExtension {
                     deps.add("wpilibc_static");
                     deps.add("ntcore_static");
                     deps.add("hal_static");
-                    deps.add("wpiutil_static");
                     deps.add("wpimath_static");
+                    deps.add("wpiutil_static");
                 });
                 configs.create("wpilib_executable_static_dt", c -> {
                     c.setLibraryName("wpilib_executable_static");
@@ -660,8 +660,8 @@ public class WPINativeUtilsExtension {
                     deps.add("wpilibc_static");
                     deps.add("ntcore_static");
                     deps.add("hal_static");
-                    deps.add("wpiutil_static");
                     deps.add("wpimath_static");
+                    deps.add("wpiutil_static");
                 });
                 configs.create("driver_static_dt", c -> {
                     c.setLibraryName("driver_static");


### PR DESCRIPTION
Get a bunch of unresolved symbols without it.
```
/Users/prateekma/.gradle/caches/transforms-2/files-2.1/70f0edbb526dd8c20db42fc076c65de1/wpimath-cpp-2021.3.1-linuxathenastaticdebug/linux/athena/static/libwpimathd.a(Rotation2d.o): In function `wpi::detail::json_ref<wpi::json>::json_ref(std::initializer_list<wpi::detail::json_ref<wpi::json> >)':
/__w/allwpilib/allwpilib/wpiutil/src/main/native/include/wpi/json.h:2284: undefined reference to `wpi::json::json(std::initializer_list<wpi::detail::json_ref<wpi::json> >, bool, wpi::detail::value_t)'
/Users/prateekma/.gradle/caches/transforms-2/files-2.1/70f0edbb526dd8c20db42fc076c65de1/wpimath-cpp-2021.3.1-linuxathenastaticdebug/linux/athena/static/libwpimathd.a(Rotation2d.o): In function `wpi::json::~json()':
/__w/allwpilib/allwpilib/wpiutil/src/main/native/include/wpi/json.h:3722: undefined reference to `wpi::json::json_value::destroy(wpi::detail::value_t)'
/Users/prateekma/.gradle/caches/transforms-2/files-2.1/70f0edbb526dd8c20db42fc076c65de1/wpimath-cpp-2021.3.1-linuxathenastaticdebug/linux/athena/static/libwpimathd.a(Rotation2d.o): In function `frc::to_json(wpi::json&, frc::Rotation2d const&)':
/__w/allwpilib/allwpilib/wpimath/src/main/native/cpp/geometry/Rotation2d.cpp:81: undefined reference to `wpi::json::json(std::initializer_list<wpi::detail::json_ref<wpi::json> >, bool, wpi::detail::value_t)'
/Users/prateekma/.gradle/caches/transforms-2/files-2.1/70f0edbb526dd8c20db42fc076c65de1/wpimath-cpp-2021.3.1-linuxathenastaticdebug/linux/athena/static/libwpimathd.a(Rotation2d.o): In function `wpi::json::~json()':
/__w/allwpilib/allwpilib/wpiutil/src/main/native/include/wpi/json.h:3722: undefined reference to `wpi::json::json_value::destroy(wpi::detail::value_t)'
/__w/allwpilib/allwpilib/wpiutil/src/main/native/include/wpi/json.h:3722: undefined reference to `wpi::json::json_value::destroy(wpi::detail::value_t)'
/__w/allwpilib/allwpilib/wpiutil/src/main/native/include/wpi/json.h:3722: undefined reference to `wpi::json::json_value::destroy(wpi::detail::value_t)'
/__w/allwpilib/allwpilib/wpiutil/src/main/native/include/wpi/json.h:3722: undefined reference to `wpi::json::json_value::destroy(wpi::detail::value_t)'
```