### PR TITLE
Skip sourcelink when cloned with SSH

### DIFF
--- a/src/main/java/edu/wpi/first/nativeutils/sourcelink/SourceLinkGenerationTask.java
+++ b/src/main/java/edu/wpi/first/nativeutils/sourcelink/SourceLinkGenerationTask.java
@@ -71,7 +71,9 @@ public class SourceLinkGenerationTask extends DefaultTask {
         final Pattern pattern = Pattern.compile(regexPattern);
         Matcher matcher = pattern.matcher(remoteUrl);
 
-        matcher.find();
+        if (!matcher.find()) {
+            return;
+        }
 
         String company = matcher.group("company");
         String project = matcher.group("project");


### PR DESCRIPTION
Closes #60 

Since SSH is rarely used on windows, and sourcelink is only useful for publishing, its not needed locally, and we can just skip it upon failure.