### PR TITLE
Add way to convert string to classes taken by dependency type map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2022.3.0"
+    version = "2022.3.1"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion


### PR DESCRIPTION
Gradle makes using classes as a type files other than the root difficult. So add a way to make this easier