### PR TITLE
Use ObjectFactory DomainObjectSet methods instead.

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDescriptor.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDescriptor.java
@@ -26,8 +26,8 @@ public class ToolchainDescriptor<T extends GccToolChain> implements ToolchainDes
         this.optional = optional;
         this.registrar = registrar;
         this.toolchainName = toolchainName;
-        this.discoverers = new DefaultNamedDomainObjectSet<ToolchainDiscoverer>(ToolchainDiscoverer.class, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP);
-        this.installers = new DefaultDomainObjectSet<AbstractToolchainInstaller>(AbstractToolchainInstaller.class, CollectionCallbackActionDecorator.NOOP);
+        this.discoverers = new ObjectFactory.namedDomainObjectSet<ToolchainDiscoverer>(ToolchainDiscoverer.class, DirectInstantiator.INSTANCE, CollectionCallbackActionDecorator.NOOP);
+        this.installers = new ObjectFactory.domainObjectSet<AbstractToolchainInstaller>(AbstractToolchainInstaller.class, CollectionCallbackActionDecorator.NOOP);
     }
 
     @Override


### PR DESCRIPTION
This adds support for Gradle 7.X. I haven't been able to test this yet, however it should work AFAIK. Feel free to test it yourself.