### PR TITLE
Allow GCC 12 to build RoboRIO code

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainExtension.java
@@ -3,7 +3,7 @@ package edu.wpi.first.toolchain.roborio;
 public class RoboRioToolchainExtension {
 
     public String versionLow = "7.3";
-    public String versionHigh = "7.3";
+    public String versionHigh = "12.1";
     public String toolchainVersion = "2022-7.3.0";
     public String toolchainTag = "v2022-1";
 


### PR DESCRIPTION
Currently, it is only possible to use a GCC version for the RoboRIO that is the same with what is expected for the RoboRIO rootfs. This change will at least make it possible to compile code against GCC 12. Work is still needed to properly deploy the correct runtime libraries that are built along with the new toolchain.