### PR TITLE
Support building natively on arm32 and arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ toolchainsPlugin {
   registerDebugBuildType = true
 
   // Add the roborio compiler
-  withRoboRIO()
+  withCrossRoboRIO()
   // Add the raspbian compiler
   withLinuxArm32()
   // The above 2 are included with nativeUtils.addWpiNativeUtils()

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ toolchainsPlugin {
   // Add the roborio compiler
   withCrossRoboRIO()
   // Add the raspbian compiler
-  withLinuxArm32()
+  withCrossLinuxArm32()
   // The above 2 are included with nativeUtils.addWpiNativeUtils()
 
   crossCompilers {

--- a/README.md
+++ b/README.md
@@ -133,7 +133,8 @@ nativeUtils.wpi.configureDependencies {
 // The 6 below get the string representation of the main platforms
 // For use comparing to binary.targetPlatform.name
 nativeUtils.wpi.platforms.roborio
-nativeUtils.wpi.platforms.raspbian
+nativeUtils.wpi.platforms.linuxarm32
+nativeUtils.wpi.platforms.linuxarm64
 nativeUtils.wpi.platforms.windowsx64
 nativeUtils.wpi.platforms.windowsx86
 nativeUtils.wpi.platforms.osxx64
@@ -168,7 +169,7 @@ toolchainsPlugin {
   // Add the roborio compiler
   withRoboRIO()
   // Add the raspbian compiler
-  withRasbian()
+  withLinuxArm32()
   // The above 2 are included with nativeUtils.addWpiNativeUtils()
 
   crossCompilers {

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
@@ -5,13 +5,16 @@ import org.gradle.internal.os.OperatingSystem;
 public class NativePlatforms {
     public static final String desktop = desktopOS() + desktopArch();
     public static final String roborio = "linuxathena";
-    public static final String raspbian = "linuxraspbian";
-    public static final String aarch64bionic = "linuxaarch64bionic";
+    public static final String linuxarm32 = "linuxarm32";
+    public static final String linuxarm64 = "linuxarm64";
 
     public static String desktopArch() {
         String arch = System.getProperty("os.arch");
         if (arch.equals("arm64") || arch.equals("aarch64")) {
             return "arm64";
+        }
+        if (arch.equals("arm32") || arch.equals("arm")) {
+            return "arm32";
         }
         return (arch.equals("amd64") || arch.equals("x86_64")) ? "x86-64" : "x86";
     }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -72,17 +72,17 @@ public class ToolchainExtension {
         // }
     }
 
-    public void withRoboRIO() {
+    public void withCrossRoboRIO() {
         project.getPluginManager().apply(RoboRioToolchainPlugin.class);
     }
 
-    public void withLinuxArm32() {
+    public void withCrossLinuxArm32() {
         if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm32)) {
             project.getPluginManager().apply(Arm32ToolchainPlugin.class);
         }
     }
 
-    public void withLinuxArm64() {
+    public void withCrossLinuxArm64() {
         if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)) {
             project.getPluginManager().apply(Arm64ToolchainPlugin.class);
         }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -77,11 +77,15 @@ public class ToolchainExtension {
     }
 
     public void withLinuxArm32() {
-        project.getPluginManager().apply(Arm32ToolchainPlugin.class);
+        if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm32)) {
+            project.getPluginManager().apply(Arm32ToolchainPlugin.class);
+        }
     }
 
     public void withLinuxArm64() {
-        project.getPluginManager().apply(Arm64ToolchainPlugin.class);
+        if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)) {
+            project.getPluginManager().apply(Arm64ToolchainPlugin.class);
+        }
     }
 
     public NamedDomainObjectContainer<ToolchainDescriptorBase> getToolchainDescriptors() {

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -11,13 +11,12 @@ import org.gradle.api.Project;
 import org.gradle.internal.logging.text.DiagnosticsVisitor;
 import org.gradle.internal.os.OperatingSystem;
 
-import edu.wpi.first.toolchain.bionic.BionicToolchainPlugin;
+import edu.wpi.first.toolchain.arm32.Arm32ToolchainPlugin;
+import edu.wpi.first.toolchain.arm64.Arm64ToolchainPlugin;
 import edu.wpi.first.toolchain.configurable.ConfigurableGcc;
 import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration;
 import edu.wpi.first.toolchain.configurable.DefaultCrossCompilerConfiguration;
-import edu.wpi.first.toolchain.raspbian.RaspbianToolchainPlugin;
 import edu.wpi.first.toolchain.roborio.RoboRioToolchainPlugin;
-//import edu.wpi.first.deployutils.toolchains.ToolchainsPlugin.ToolchainUtilExtension;
 
 public class ToolchainExtension {
     private final NamedDomainObjectContainer<CrossCompilerConfiguration> crossCompilers;
@@ -77,12 +76,12 @@ public class ToolchainExtension {
         project.getPluginManager().apply(RoboRioToolchainPlugin.class);
     }
 
-    public void withRaspbian() {
-        project.getPluginManager().apply(RaspbianToolchainPlugin.class);
+    public void withLinuxArm32() {
+        project.getPluginManager().apply(Arm32ToolchainPlugin.class);
     }
 
-    public void withBionic() {
-        project.getPluginManager().apply(BionicToolchainPlugin.class);
+    public void withLinuxArm64() {
+        project.getPluginManager().apply(Arm64ToolchainPlugin.class);
     }
 
     public NamedDomainObjectContainer<ToolchainDescriptorBase> getToolchainDescriptors() {

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
@@ -160,6 +160,9 @@ public class ToolchainRules extends RuleSource {
             }
 
             for (CrossCompilerConfiguration config : ext.getCrossCompilers()) {
+                if (config.getName().equals(NativePlatforms.desktop)) {
+                    continue;
+                }
                 NativePlatform configedPlatform = platforms.maybeCreate(config.getName(), NativePlatform.class);
                 configedPlatform.architecture(config.getArchitecture());
                 configedPlatform.operatingSystem(config.getOperatingSystem());

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
@@ -52,6 +52,13 @@ public class ToolchainRules extends RuleSource {
     @Finalize
     void addClangArm(NativeToolChainRegistryInternal toolChainRegistry) {
         toolChainRegistry.all(n -> {
+            if (n instanceof org.gradle.nativeplatform.toolchain.internal.gcc.GccToolChain && OperatingSystem.current().equals(OperatingSystem.LINUX)) {
+                AbstractGccCompatibleToolChain gcc = (AbstractGccCompatibleToolChain)n;
+                if (NativePlatforms.desktop.equals(NativePlatforms.linuxarm32) || NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)) {
+                    gcc.setTargets();
+                    gcc.target(NativePlatforms.desktop);
+                }
+            }
             if (n instanceof ClangToolChain && OperatingSystem.current().equals(OperatingSystem.MAC_OS)) {
                 AbstractGccCompatibleToolChain gcc = (AbstractGccCompatibleToolChain)n;
                 gcc.setTargets();

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32Gcc.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32Gcc.java
@@ -1,16 +1,16 @@
-package edu.wpi.first.toolchain.raspbian;
+package edu.wpi.first.toolchain.arm32;
 
 import edu.wpi.first.toolchain.GccToolChain;
 import edu.wpi.first.toolchain.ToolchainOptions;
 
-public class RaspbianGcc extends GccToolChain {
+public class Arm32Gcc extends GccToolChain {
 
-    public RaspbianGcc(ToolchainOptions options) {
+    public Arm32Gcc(ToolchainOptions options) {
         super(options);
     }
 
     @Override
     protected String getTypeName() {
-        return "RaspbianGcc";
+        return "Arm32Gcc";
     }
 }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainExtension.java
@@ -1,6 +1,6 @@
-package edu.wpi.first.toolchain.raspbian;
+package edu.wpi.first.toolchain.arm32;
 
-public class RaspbianToolchainExtension {
+public class Arm32ToolchainExtension {
 
     public String versionLow = "8.3";
     public String versionHigh = "8.3";

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
@@ -1,4 +1,4 @@
-package edu.wpi.first.toolchain.bionic;
+package edu.wpi.first.toolchain.arm32;
 
 import edu.wpi.first.toolchain.*;
 import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration;
@@ -14,37 +14,37 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-public class BionicToolchainPlugin implements Plugin<Project> {
+public class Arm32ToolchainPlugin implements Plugin<Project> {
 
-    public static final String toolchainName = "bionic";
+    public static final String toolchainName = "arm32";
 
-    private BionicToolchainExtension bionicExt;
+    private Arm32ToolchainExtension arm32Ext;
     private Project project;
 
     @Override
     public void apply(Project project) {
         this.project = project;
 
-        bionicExt = project.getExtensions().create("bionicToolchain", BionicToolchainExtension.class);
+        arm32Ext = project.getExtensions().create("arm32Toolchain", Arm32ToolchainExtension.class);
 
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
         Property<Boolean> optional = project.getObjects().property(Boolean.class);
         optional.set(true);
 
-        ToolchainDescriptor<BionicGcc> descriptor = new ToolchainDescriptor<>(
-            project, 
+        ToolchainDescriptor<Arm32Gcc> descriptor = new ToolchainDescriptor<>(
+            project,
             toolchainName,
-            "bionicGcc",
-            new ToolchainRegistrar<BionicGcc>(BionicGcc.class, project), 
+            "arm32Gcc",
+            new ToolchainRegistrar<Arm32Gcc>(Arm32Gcc.class, project),
             optional);
-        descriptor.setToolchainPlatforms(NativePlatforms.aarch64bionic);
+        descriptor.setToolchainPlatforms(NativePlatforms.linuxarm32);
         descriptor.getDiscoverers().all((ToolchainDiscoverer disc) -> {
-            disc.configureVersions(bionicExt.versionLow, bionicExt.versionHigh);
+            disc.configureVersions(arm32Ext.versionLow, arm32Ext.versionHigh);
         });
 
-        CrossCompilerConfiguration configuration = new DefaultCrossCompilerConfiguration(NativePlatforms.aarch64bionic, descriptor, optional);
-        configuration.setArchitecture("aarch64");
+        CrossCompilerConfiguration configuration = new DefaultCrossCompilerConfiguration(NativePlatforms.linuxarm32, descriptor, optional);
+        configuration.setArchitecture("arm");
         configuration.setOperatingSystem("linux");
         configuration.setCompilerPrefix("");
 
@@ -61,22 +61,22 @@ public class BionicToolchainPlugin implements Plugin<Project> {
     }
 
     public String composeTool(String toolName) {
-        String bionicVersion = bionicExt.toolchainVersion.split("-")[0].toLowerCase();
+        String arm32Version = arm32Ext.toolchainVersion.split("-")[0].toLowerCase();
         String exeSuffix = OperatingSystem.current().isWindows() ? ".exe" : "";
-        return "aarch64-" + bionicVersion + "-linux-gnu-" + toolName + exeSuffix;
+        return "arm-" + arm32Version + "-linux-gnueabihf-" + toolName + exeSuffix;
     }
 
-    public void populateDescriptor(ToolchainDescriptor<BionicGcc> descriptor) {
-        String bionicVersion = bionicExt.toolchainVersion.split("-")[0].toLowerCase();
-        File installLoc = toolchainInstallLoc(bionicVersion);
+    public void populateDescriptor(ToolchainDescriptor<Arm32Gcc> descriptor) {
+        String arm32Version = arm32Ext.toolchainVersion.split("-")[0].toLowerCase();
+        File installLoc = toolchainInstallLoc(arm32Version);
 
         descriptor.getDiscoverers().add(ToolchainDiscoverer.create("GradleUserDir", installLoc, this::composeTool, project));
         descriptor.getDiscoverers().addAll(ToolchainDiscoverer.forSystemPath(project, this::composeTool));
 
         try {
-            descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, installLoc, bionicVersion));
-            descriptor.getInstallers().add(installerFor(OperatingSystem.WINDOWS, installLoc, bionicVersion));
-            descriptor.getInstallers().add(installerFor(OperatingSystem.MAC_OS, installLoc, bionicVersion));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, installLoc, arm32Version));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.WINDOWS, installLoc, arm32Version));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.MAC_OS, installLoc, arm32Version));
         } catch (MalformedURLException e) {
             throw new GradleException("Malformed Toolchain URL", e);
         }
@@ -88,7 +88,7 @@ public class BionicToolchainPlugin implements Plugin<Project> {
     }
 
     private String toolchainRemoteFile() {
-        String[] desiredVersion = bionicExt.toolchainVersion.split("-");
+        String[] desiredVersion = arm32Ext.toolchainVersion.split("-");
 
         String platformId;
         if (OperatingSystem.current().isWindows()) {
@@ -103,7 +103,7 @@ public class BionicToolchainPlugin implements Plugin<Project> {
     }
 
     private URL toolchainDownloadUrl(String file) throws MalformedURLException {
-        return new URL("https://github.com/wpilibsuite/aarch64-bionic-toolchain/releases/download/" + bionicExt.toolchainTag + "/" + file);
+        return new URL("https://github.com/wpilibsuite/raspbian-toolchain/releases/download/" + arm32Ext.toolchainTag + "/" + file);
     }
 
 }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64Gcc.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64Gcc.java
@@ -1,16 +1,16 @@
-package edu.wpi.first.toolchain.bionic;
+package edu.wpi.first.toolchain.arm64;
 
 import edu.wpi.first.toolchain.GccToolChain;
 import edu.wpi.first.toolchain.ToolchainOptions;
 
-public class BionicGcc extends GccToolChain {
+public class Arm64Gcc extends GccToolChain {
 
-    public BionicGcc(ToolchainOptions options) {
+    public Arm64Gcc(ToolchainOptions options) {
         super(options);
     }
 
     @Override
     protected String getTypeName() {
-        return "BionicGcc";
+        return "Arm64Gcc";
     }
 }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainExtension.java
@@ -1,6 +1,6 @@
-package edu.wpi.first.toolchain.bionic;
+package edu.wpi.first.toolchain.arm64;
 
-public class BionicToolchainExtension {
+public class Arm64ToolchainExtension {
 
     public String versionLow = "8.4";
     public String versionHigh = "8.4";

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
@@ -1,4 +1,4 @@
-package edu.wpi.first.toolchain.raspbian;
+package edu.wpi.first.toolchain.arm64;
 
 import edu.wpi.first.toolchain.*;
 import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration;
@@ -14,37 +14,37 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-public class RaspbianToolchainPlugin implements Plugin<Project> {
+public class Arm64ToolchainPlugin implements Plugin<Project> {
 
-    public static final String toolchainName = "raspbian";
+    public static final String toolchainName = "arm64";
 
-    private RaspbianToolchainExtension raspbianExt;
+    private Arm64ToolchainExtension arm64Ext;
     private Project project;
 
     @Override
     public void apply(Project project) {
         this.project = project;
 
-        raspbianExt = project.getExtensions().create("raspbianToolchain", RaspbianToolchainExtension.class);
+        arm64Ext = project.getExtensions().create("arm64Toolchain", Arm64ToolchainExtension.class);
 
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
         Property<Boolean> optional = project.getObjects().property(Boolean.class);
         optional.set(true);
 
-        ToolchainDescriptor<RaspbianGcc> descriptor = new ToolchainDescriptor<>(
+        ToolchainDescriptor<Arm64Gcc> descriptor = new ToolchainDescriptor<>(
             project,
             toolchainName,
-            "raspianGcc",
-            new ToolchainRegistrar<RaspbianGcc>(RaspbianGcc.class, project),
+            "arm64Gcc",
+            new ToolchainRegistrar<Arm64Gcc>(Arm64Gcc.class, project),
             optional);
-        descriptor.setToolchainPlatforms(NativePlatforms.raspbian);
+        descriptor.setToolchainPlatforms(NativePlatforms.linuxarm64);
         descriptor.getDiscoverers().all((ToolchainDiscoverer disc) -> {
-            disc.configureVersions(raspbianExt.versionLow, raspbianExt.versionHigh);
+            disc.configureVersions(arm64Ext.versionLow, arm64Ext.versionHigh);
         });
 
-        CrossCompilerConfiguration configuration = new DefaultCrossCompilerConfiguration(NativePlatforms.raspbian, descriptor, optional);
-        configuration.setArchitecture("arm");
+        CrossCompilerConfiguration configuration = new DefaultCrossCompilerConfiguration(NativePlatforms.linuxarm64, descriptor, optional);
+        configuration.setArchitecture("arm64");
         configuration.setOperatingSystem("linux");
         configuration.setCompilerPrefix("");
 
@@ -61,22 +61,22 @@ public class RaspbianToolchainPlugin implements Plugin<Project> {
     }
 
     public String composeTool(String toolName) {
-        String raspbianVersion = raspbianExt.toolchainVersion.split("-")[0].toLowerCase();
+        String arm64Version = arm64Ext.toolchainVersion.split("-")[0].toLowerCase();
         String exeSuffix = OperatingSystem.current().isWindows() ? ".exe" : "";
-        return "arm-" + raspbianVersion + "-linux-gnueabihf-" + toolName + exeSuffix;
+        return "aarch64-" + arm64Version + "-linux-gnu-" + toolName + exeSuffix;
     }
 
-    public void populateDescriptor(ToolchainDescriptor<RaspbianGcc> descriptor) {
-        String raspbianVersion = raspbianExt.toolchainVersion.split("-")[0].toLowerCase();
-        File installLoc = toolchainInstallLoc(raspbianVersion);
+    public void populateDescriptor(ToolchainDescriptor<Arm64Gcc> descriptor) {
+        String arm64Version = arm64Ext.toolchainVersion.split("-")[0].toLowerCase();
+        File installLoc = toolchainInstallLoc(arm64Version);
 
         descriptor.getDiscoverers().add(ToolchainDiscoverer.create("GradleUserDir", installLoc, this::composeTool, project));
         descriptor.getDiscoverers().addAll(ToolchainDiscoverer.forSystemPath(project, this::composeTool));
 
         try {
-            descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, installLoc, raspbianVersion));
-            descriptor.getInstallers().add(installerFor(OperatingSystem.WINDOWS, installLoc, raspbianVersion));
-            descriptor.getInstallers().add(installerFor(OperatingSystem.MAC_OS, installLoc, raspbianVersion));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, installLoc, arm64Version));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.WINDOWS, installLoc, arm64Version));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.MAC_OS, installLoc, arm64Version));
         } catch (MalformedURLException e) {
             throw new GradleException("Malformed Toolchain URL", e);
         }
@@ -88,7 +88,7 @@ public class RaspbianToolchainPlugin implements Plugin<Project> {
     }
 
     private String toolchainRemoteFile() {
-        String[] desiredVersion = raspbianExt.toolchainVersion.split("-");
+        String[] desiredVersion = arm64Ext.toolchainVersion.split("-");
 
         String platformId;
         if (OperatingSystem.current().isWindows()) {
@@ -103,7 +103,7 @@ public class RaspbianToolchainPlugin implements Plugin<Project> {
     }
 
     private URL toolchainDownloadUrl(String file) throws MalformedURLException {
-        return new URL("https://github.com/wpilibsuite/raspbian-toolchain/releases/download/" + raspbianExt.toolchainTag + "/" + file);
+        return new URL("https://github.com/wpilibsuite/aarch64-bionic-toolchain/releases/download/" + arm64Ext.toolchainTag + "/" + file);
     }
 
 }

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
@@ -43,6 +43,6 @@ toolchainsPlugin.withLinuxArm32()
                              .build()
 
     then:
-    result.task(':installArm64Toolchain').outcome == SUCCESS
+    result.task(':installArm32Toolchain').outcome == SUCCESS
   }
 }

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
@@ -33,7 +33,7 @@ class Arm32DownloadTest extends Specification {
   id 'edu.wpi.first.Toolchain'
 }
 
-toolchainsPlugin.withLinuxArm32()
+toolchainsPlugin.withCrossLinuxArm32()
 """
     when:
     def result = GradleRunner.create()

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
@@ -1,4 +1,4 @@
-package edu.wpi.first.toolchain.bionic
+package edu.wpi.first.toolchain.arm32
 
 import org.gradle.testkit.runner.GradleRunner
 import static org.gradle.testkit.runner.TaskOutcome.*
@@ -9,7 +9,7 @@ import spock.lang.Specification
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ !Boolean.valueOf(env['SPOCK_RUN_TOOLCHAINS']) })
-class BionicDownloadTest extends Specification {
+class Arm32DownloadTest extends Specification {
   @TempDir File testProjectDir
   File buildFile
   @Shared File toolchainDir
@@ -19,9 +19,9 @@ class BionicDownloadTest extends Specification {
   }
 
   def setupSpec() {
-    BionicToolchainExtension ext = new BionicToolchainExtension()
-    String bionicVersion = ext.toolchainVersion.split("-")[0].toLowerCase();
-    toolchainDir = BionicToolchainPlugin.toolchainInstallLoc(bionicVersion)
+    Arm32ToolchainExtension ext = new Arm32ToolchainExtension()
+    String arm32Version = ext.toolchainVersion.split("-")[0].toLowerCase();
+    toolchainDir = Arm32ToolchainPlugin.toolchainInstallLoc(arm32Version)
     def result = toolchainDir.deleteDir()  // Returns true if all goes well, false otherwise.
     assert result
   }
@@ -33,16 +33,16 @@ class BionicDownloadTest extends Specification {
   id 'edu.wpi.first.Toolchain'
 }
 
-toolchainsPlugin.withBionic()
+toolchainsPlugin.withLinuxArm32()
 """
     when:
     def result = GradleRunner.create()
                              .withProjectDir(testProjectDir)
-                             .withArguments('installBionicToolchain', '--stacktrace')
+                             .withArguments('installArm32Toolchain', '--stacktrace')
                              .withPluginClasspath()
                              .build()
 
     then:
-    result.task(':installBionicToolchain').outcome == SUCCESS
+    result.task(':installArm64Toolchain').outcome == SUCCESS
   }
 }

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm64/Arm64DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm64/Arm64DownloadTest.groovy
@@ -33,7 +33,7 @@ class Arm64DownloadTest extends Specification {
   id 'edu.wpi.first.Toolchain'
 }
 
-toolchainsPlugin.withLinuxArm64()
+toolchainsPlugin.withCrossLinuxArm64()
 """
     when:
     def result = GradleRunner.create()

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm64/Arm64DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm64/Arm64DownloadTest.groovy
@@ -1,4 +1,4 @@
-package edu.wpi.first.toolchain.raspbian
+package edu.wpi.first.toolchain.arm64
 
 import org.gradle.testkit.runner.GradleRunner
 import static org.gradle.testkit.runner.TaskOutcome.*
@@ -9,7 +9,7 @@ import spock.lang.Specification
 import spock.lang.IgnoreIf
 
 @IgnoreIf({ !Boolean.valueOf(env['SPOCK_RUN_TOOLCHAINS']) })
-class RaspbianDownloadTest extends Specification {
+class Arm64DownloadTest extends Specification {
   @TempDir File testProjectDir
   File buildFile
   @Shared File toolchainDir
@@ -19,9 +19,9 @@ class RaspbianDownloadTest extends Specification {
   }
 
   def setupSpec() {
-    RaspbianToolchainExtension ext = new RaspbianToolchainExtension()
-    String raspbianVersion = ext.toolchainVersion.split("-")[0].toLowerCase();
-    toolchainDir = RaspbianToolchainPlugin.toolchainInstallLoc(raspbianVersion)
+    Arm64ToolchainExtension ext = new Arm64ToolchainExtension()
+    String arm64Version = ext.toolchainVersion.split("-")[0].toLowerCase();
+    toolchainDir = Arm64ToolchainPlugin.toolchainInstallLoc(arm64Version)
     def result = toolchainDir.deleteDir()  // Returns true if all goes well, false otherwise.
     assert result
   }
@@ -33,16 +33,16 @@ class RaspbianDownloadTest extends Specification {
   id 'edu.wpi.first.Toolchain'
 }
 
-toolchainsPlugin.withRaspbian()
+toolchainsPlugin.withLinuxArm64()
 """
     when:
     def result = GradleRunner.create()
                              .withProjectDir(testProjectDir)
-                             .withArguments('installRaspbianToolchain', '--stacktrace')
+                             .withArguments('installArm64Toolchain', '--stacktrace')
                              .withPluginClasspath()
                              .build()
 
     then:
-    result.task(':installRaspbianToolchain').outcome == SUCCESS
+    result.task(':installArm64Toolchain').outcome == SUCCESS
   }
 }

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/roborio/RoborioDownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/roborio/RoborioDownloadTest.groovy
@@ -33,7 +33,7 @@ class RoboRioDownloadTest extends Specification {
   id 'edu.wpi.first.Toolchain'
 }
 
-toolchainsPlugin.withRoboRIO()
+toolchainsPlugin.withCrossRoboRIO()
 """
     when:
     def result = GradleRunner.create()

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2023.0.3"
+    version = "2023.0.4"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
@@ -359,11 +359,15 @@ public class NativeUtilsExtension {
   }
 
   public void withLinuxArm32() {
-    project.getPluginManager().apply(Arm32ToolchainPlugin.class);
+    if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm32)) {
+      project.getPluginManager().apply(Arm32ToolchainPlugin.class);
+    }
   }
 
   public void withLinuxArm64() {
-    project.getPluginManager().apply(Arm64ToolchainPlugin.class);
+    if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)) {
+      project.getPluginManager().apply(Arm64ToolchainPlugin.class);
+    }
   }
 
   public void excludeBinariesFromStrip(VariantComponentSpec component) {

--- a/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
@@ -44,9 +44,9 @@ import edu.wpi.first.nativeutils.tasks.PrintNativeDependenciesTask;
 import edu.wpi.first.toolchain.NativePlatforms;
 import edu.wpi.first.toolchain.ToolchainDescriptorBase;
 import edu.wpi.first.toolchain.ToolchainExtension;
-import edu.wpi.first.toolchain.bionic.BionicToolchainPlugin;
+import edu.wpi.first.toolchain.arm32.Arm32ToolchainPlugin;
+import edu.wpi.first.toolchain.arm64.Arm64ToolchainPlugin;
 import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration;
-import edu.wpi.first.toolchain.raspbian.RaspbianToolchainPlugin;
 import edu.wpi.first.toolchain.roborio.RoboRioToolchainPlugin;
 
 public class NativeUtilsExtension {
@@ -358,12 +358,12 @@ public class NativeUtilsExtension {
     project.getPluginManager().apply(RoboRioToolchainPlugin.class);
   }
 
-  public void withRaspbian() {
-    project.getPluginManager().apply(RaspbianToolchainPlugin.class);
+  public void withLinuxArm32() {
+    project.getPluginManager().apply(Arm32ToolchainPlugin.class);
   }
 
-  public void withBionic() {
-    project.getPluginManager().apply(BionicToolchainPlugin.class);
+  public void withLinuxArm64() {
+    project.getPluginManager().apply(Arm64ToolchainPlugin.class);
   }
 
   public void excludeBinariesFromStrip(VariantComponentSpec component) {

--- a/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
@@ -354,17 +354,17 @@ public class NativeUtilsExtension {
     return project.getTasks().register(name, ResourceGenerationTask.class, configure);
   }
 
-  public void withRoboRIO() {
+  public void withCrossRoboRIO() {
     project.getPluginManager().apply(RoboRioToolchainPlugin.class);
   }
 
-  public void withLinuxArm32() {
+  public void withCrossLinuxArm32() {
     if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm32)) {
       project.getPluginManager().apply(Arm32ToolchainPlugin.class);
     }
   }
 
-  public void withLinuxArm64() {
+  public void withCrossLinuxArm64() {
     if (!NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)) {
       project.getPluginManager().apply(Arm64ToolchainPlugin.class);
     }

--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -76,13 +76,13 @@ public class WPINativeUtilsExtension {
 
     public static class Platforms {
         public final String roborio = "linuxathena";
-        public final String raspbian = "linuxraspbian";
+        public final String linuxarm32 = "linuxarm32";
         public final String windowsx64 = "windowsx86-64";
         public final String osxx64 = "osxx86-64";
         public final String osxarm64 = "osxarm64";
         public final String linuxx64 = "linuxx86-64";
-        public final String aarch64bionic = "linuxaarch64bionic";
-        public final List<String> allPlatforms = List.of(roborio, raspbian, aarch64bionic, windowsx64,
+        public final String linuxarm64 = "linuxarm64";
+        public final List<String> allPlatforms = List.of(roborio, linuxarm32, linuxarm64, windowsx64,
                 osxx64, osxarm64, linuxx64);
         public final List<String> desktopPlatforms = List.of(windowsx64, osxx64, osxarm64, linuxx64);
     }
@@ -171,23 +171,23 @@ public class WPINativeUtilsExtension {
         PlatformConfig osxx86_64 = nativeExt.getPlatformConfigs().create(platforms.osxx64);
         PlatformConfig osxarm64 = nativeExt.getPlatformConfigs().create(platforms.osxarm64);
         PlatformConfig linuxathena = nativeExt.getPlatformConfigs().create(platforms.roborio);
-        PlatformConfig linuxraspbian = nativeExt.getPlatformConfigs().create(platforms.raspbian);
-        PlatformConfig linuxbionic = nativeExt.getPlatformConfigs().create(platforms.aarch64bionic);
+        PlatformConfig linuxarm32 = nativeExt.getPlatformConfigs().create(platforms.linuxarm32);
+        PlatformConfig linuxarm64 = nativeExt.getPlatformConfigs().create(platforms.linuxarm64);
         unixPlatforms.put(platforms.linuxx64, linuxx86_64);
         unixPlatforms.put(platforms.osxx64, osxx86_64);
         unixPlatforms.put(platforms.osxarm64, osxarm64);
-        unixPlatforms.put(platforms.raspbian, linuxraspbian);
+        unixPlatforms.put(platforms.linuxarm32, linuxarm32);
         unixPlatforms.put(platforms.roborio, linuxathena);
-        unixPlatforms.put(platforms.aarch64bionic, linuxbionic);
+        unixPlatforms.put(platforms.linuxarm64, linuxarm64);
 
         linuxathena.getPlatformPath().set("linux/athena");
         addLinuxCrossArgs(linuxathena);
 
-        linuxraspbian.getPlatformPath().set("linux/raspbian");
-        addLinuxCrossArgs(linuxraspbian);
+        linuxarm32.getPlatformPath().set("linux/arm32");
+        addLinuxCrossArgs(linuxarm32);
 
-        linuxbionic.getPlatformPath().set("linux/aarch64bionic");
-        addLinuxCrossArgs(linuxbionic);
+        linuxarm64.getPlatformPath().set("linux/arm64");
+        addLinuxCrossArgs(linuxarm64);
 
         windowsx86_64.getPlatformPath().set("windows/x86-64");
         addWindowsArgs(windowsx86_64);


### PR DESCRIPTION
Also, because arm has gotten a bit better, rename raspbian to arm32 and bionic to arm64. We probably should also investigate moving the bionic compiler to arm64 raspberry pi builds.