### PR TITLE
Disable all run test tasks except for the native build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2023.0.6"
+    version = "2023.0.7"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion


### PR DESCRIPTION
On intel mac systems, when doing a dual build, we can't run the arm64 tests. Modify the existing code that disables cross compiled tests to work for any non native build. This would cause win32 tests to not be able to be ran, however since we've removed win32 that is no longer a concern. We can always special case any builds in the future that would work. Technically we could allow m1 macs to run intel tests, but probably not worth doing so.

Uses a pre initialized interface both to reduce allocations, and ensure we don't break incremental builds.

Tested on mac to know it works.