### PR TITLE
Use mac hw platform for compiler arch

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/DefaultToolchainInstaller.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/DefaultToolchainInstaller.java
@@ -10,23 +10,25 @@ import org.gradle.internal.os.OperatingSystem;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.function.Supplier;
 
 public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
 
     private OperatingSystem os;
-    private URL source;
+    private Supplier<URL> sourceSupplier;
     private File installDir;
     private String subdir;
 
-    public DefaultToolchainInstaller(OperatingSystem os, URL source, File installDir, String subdir) {
+    public DefaultToolchainInstaller(OperatingSystem os, Supplier<URL> source, File installDir, String subdir) {
         this.os = os;
-        this.source = source;
+        this.sourceSupplier = source;
         this.installDir = installDir;
         this.subdir = subdir;
     }
 
     @Override
     public void install(Project project) {
+        URL source = sourceSupplier.get();
         File cacheLoc = new File(ToolchainPlugin.gradleHome(), "cache");
         File dst = new File(cacheLoc, "download/" + source.getPath());
         dst.getParentFile().mkdirs();

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
@@ -1,8 +1,9 @@
 package edu.wpi.first.toolchain;
 
+import java.io.ByteArrayOutputStream;
+
 import org.gradle.api.Project;
 import org.gradle.internal.os.OperatingSystem;
-import org.gradle.process.ExecResult;
 
 public class NativePlatforms {
     public static final String desktop = desktopOS() + desktopArch();
@@ -22,6 +23,7 @@ public class NativePlatforms {
     }
 
     public static String desktopPlatformArch(Project project) {
+        System.out.println("Getting Platform Arch");
         if (OperatingSystem.current().isWindows()) {
             String arch = System.getenv("PROCESSOR_ARCHITECTURE");
             String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
@@ -29,10 +31,14 @@ public class NativePlatforms {
         } else if (OperatingSystem.current().isMacOsX()) {
             String desktop = desktopArch();
             if (desktop.equals("x86-64")) {
-                ExecResult res = project.exec(spec -> {
-                    spec.commandLine("sysctl", "-in", "systtl.proc_translated");
+                ByteArrayOutputStream os = new ByteArrayOutputStream();
+                project.exec(spec -> {
+                    spec.commandLine("sysctl", "-in", "sysctl.proc_translated");
+                    spec.setStandardOutput(os);
+                    spec.setIgnoreExitValue(true);
                 });
-                return res.getExitValue() != 0 ? "arm64" : desktop;
+                String isTranslated = os.toString().trim();
+                return isTranslated.equals("1") ? "arm64" : desktop;
             } else {
                 return desktop;
             }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
@@ -2,7 +2,6 @@ package edu.wpi.first.toolchain;
 
 import java.io.ByteArrayOutputStream;
 
-import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.internal.os.OperatingSystem;
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
@@ -2,6 +2,7 @@ package edu.wpi.first.toolchain;
 
 import java.io.ByteArrayOutputStream;
 
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.internal.os.OperatingSystem;
 
@@ -23,7 +24,6 @@ public class NativePlatforms {
     }
 
     public static String desktopPlatformArch(Project project) {
-        System.out.println("Getting Platform Arch");
         if (OperatingSystem.current().isWindows()) {
             String arch = System.getenv("PROCESSOR_ARCHITECTURE");
             String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
@@ -1,6 +1,8 @@
 package edu.wpi.first.toolchain;
 
+import org.gradle.api.Project;
 import org.gradle.internal.os.OperatingSystem;
+import org.gradle.process.ExecResult;
 
 public class NativePlatforms {
     public static final String desktop = desktopOS() + desktopArch();
@@ -19,11 +21,21 @@ public class NativePlatforms {
         return (arch.equals("amd64") || arch.equals("x86_64")) ? "x86-64" : "x86";
     }
 
-    public static String desktopPlatformArch() {
+    public static String desktopPlatformArch(Project project) {
         if (OperatingSystem.current().isWindows()) {
             String arch = System.getenv("PROCESSOR_ARCHITECTURE");
             String wow64Arch = System.getenv("PROCESSOR_ARCHITEW6432");
             return arch != null && arch.endsWith("64") || wow64Arch != null && wow64Arch.endsWith("64") ? "x86-64" : "x86";
+        } else if (OperatingSystem.current().isMacOsX()) {
+            String desktop = desktopArch();
+            if (desktop.equals("x86-64")) {
+                ExecResult res = project.exec(spec -> {
+                    spec.commandLine("sysctl", "-in", "systtl.proc_translated");
+                });
+                return res.getExitValue() != 0 ? "arm64" : desktop;
+            } else {
+                return desktop;
+            }
         } else {
             return desktopArch();
         }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
@@ -84,9 +84,10 @@ public class Arm32ToolchainPlugin implements Plugin<Project> {
     }
 
     private AbstractToolchainInstaller installerFor(OperatingSystem os, File installDir, String subdir) throws MalformedURLException {
-        URL url = toolchainDownloadUrl(toolchainRemoteFile());
-        return new DefaultToolchainInstaller(os, url, installDir, subdir);
+        return new DefaultToolchainInstaller(os, this::toolchainDownloadUrl, installDir, subdir);
     }
+
+    private final String baseToolchainName = "armhf-raspi-bullseye-";
 
     private String toolchainRemoteFile() {
         String[] desiredVersion = arm32Ext.toolchainVersion.split("-");
@@ -100,11 +101,16 @@ public class Arm32ToolchainPlugin implements Plugin<Project> {
             platformId = "x86_64-linux-gnu";
         }
         String ext = OperatingSystem.current().isWindows() ? "zip" : "tgz";
-        return "armhf-raspi-bullseye-" + desiredVersion[0] + "-" + platformId + "-Toolchain-" + desiredVersion[1] + "." + ext;
+        return baseToolchainName + desiredVersion[0] + "-" + platformId + "-Toolchain-" + desiredVersion[1] + "." + ext;
     }
 
-    private URL toolchainDownloadUrl(String file) throws MalformedURLException {
-        return new URL("https://github.com/wpilibsuite/opensdk/releases/download/" + arm32Ext.toolchainTag + "/" + file);
+    private URL toolchainDownloadUrl() {
+        String file = toolchainRemoteFile();
+        try {
+            return new URL("https://github.com/wpilibsuite/opensdk/releases/download/" + arm32Ext.toolchainTag + "/" + file);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
@@ -95,7 +95,7 @@ public class Arm32ToolchainPlugin implements Plugin<Project> {
         if (OperatingSystem.current().isWindows()) {
             platformId = "x86_64-w64-mingw32";
         } else if (OperatingSystem.current().isMacOsX()) {
-            platformId = (NativePlatforms.desktopPlatformArch() == "x86-64" ? "x86_64" : "arm64") + "-apple-darwin";
+            platformId = (NativePlatforms.desktopPlatformArch(project) == "x86-64" ? "x86_64" : "arm64") + "-apple-darwin";
         } else {
             platformId = "x86_64-linux-gnu";
         }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
@@ -95,7 +95,7 @@ public class Arm64ToolchainPlugin implements Plugin<Project> {
         if (OperatingSystem.current().isWindows()) {
             platformId = "x86_64-w64-mingw32";
         } else if (OperatingSystem.current().isMacOsX()) {
-            platformId = (NativePlatforms.desktopPlatformArch() == "x86-64" ? "x86_64" : "arm64") + "-apple-darwin";
+            platformId = (NativePlatforms.desktopPlatformArch(project) == "x86-64" ? "x86_64" : "arm64") + "-apple-darwin";
         } else {
             platformId = "x86_64-linux-gnu";
         }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
@@ -84,9 +84,10 @@ public class Arm64ToolchainPlugin implements Plugin<Project> {
     }
 
     private AbstractToolchainInstaller installerFor(OperatingSystem os, File installDir, String subdir) throws MalformedURLException {
-        URL url = toolchainDownloadUrl(toolchainRemoteFile());
-        return new DefaultToolchainInstaller(os, url, installDir, subdir);
+        return new DefaultToolchainInstaller(os, this::toolchainDownloadUrl, installDir, subdir);
     }
+
+    private final String baseToolchainName = "arm64-bullseye-";
 
     private String toolchainRemoteFile() {
         String[] desiredVersion = arm64Ext.toolchainVersion.split("-");
@@ -100,11 +101,16 @@ public class Arm64ToolchainPlugin implements Plugin<Project> {
             platformId = "x86_64-linux-gnu";
         }
         String ext = OperatingSystem.current().isWindows() ? "zip" : "tgz";
-        return "arm64-bullseye-" + desiredVersion[0] + "-" + platformId + "-Toolchain-" + desiredVersion[1] + "." + ext;
+        return baseToolchainName + desiredVersion[0] + "-" + platformId + "-Toolchain-" + desiredVersion[1] + "." + ext;
     }
 
-    private URL toolchainDownloadUrl(String file) throws MalformedURLException {
-        return new URL("https://github.com/wpilibsuite/opensdk/releases/download/" + arm64Ext.toolchainTag + "/" + file);
+    private URL toolchainDownloadUrl() {
+        String file = toolchainRemoteFile();
+        try {
+            return new URL("https://github.com/wpilibsuite/opensdk/releases/download/" + arm64Ext.toolchainTag + "/" + file);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
@@ -95,7 +95,7 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
         if (OperatingSystem.current().isWindows()) {
             platformId = "x86_64-w64-mingw32";
         } else if (OperatingSystem.current().isMacOsX()) {
-            platformId = (NativePlatforms.desktopPlatformArch() == "x86-64" ? "x86_64" : "arm64") + "-apple-darwin";
+            platformId = (NativePlatforms.desktopPlatformArch(project) == "x86-64" ? "x86_64" : "arm64") + "-apple-darwin";
         } else {
             platformId = "x86_64-linux-gnu";
         }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
@@ -84,9 +84,10 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
     }
 
     private AbstractToolchainInstaller installerFor(OperatingSystem os, File installDir, String subdir) throws MalformedURLException {
-        URL url = toolchainDownloadUrl(toolchainRemoteFile());
-        return new DefaultToolchainInstaller(os, url, installDir, subdir);
+        return new DefaultToolchainInstaller(os, this::toolchainDownloadUrl, installDir, subdir);
     }
+
+    private final String baseToolchainName = "cortexa9_vfpv3-roborio-academic-";
 
     private String toolchainRemoteFile() {
         String[] desiredVersion = roborioExt.toolchainVersion.split("-");
@@ -100,11 +101,16 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
             platformId = "x86_64-linux-gnu";
         }
         String ext = OperatingSystem.current().isWindows() ? "zip" : "tgz";
-        return "cortexa9_vfpv3-roborio-academic-" + desiredVersion[0] + "-" + platformId + "-Toolchain-" + desiredVersion[1] + "." + ext;
+        return baseToolchainName + desiredVersion[0] + "-" + platformId + "-Toolchain-" + desiredVersion[1] + "." + ext;
     }
 
-    private URL toolchainDownloadUrl(String file) throws MalformedURLException {
-        return new URL("https://github.com/wpilibsuite/opensdk/releases/download/" + roborioExt.toolchainTag + "/" + file);
+    private URL toolchainDownloadUrl() {
+        String file = toolchainRemoteFile();
+        try {
+            return new URL("https://github.com/wpilibsuite/opensdk/releases/download/" + roborioExt.toolchainTag + "/" + file);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
     }
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2023.2.1"
+    version = "2023.2.2"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion


### PR DESCRIPTION
This makes it so an arm cross compiler will be used even with an intel jdk. Because the call can be expensive, lazily compute the hw arch only when necessary.