### PR TITLE
Fix native utils crashing when a non runnable compiler is found

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDiscoverer.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDiscoverer.java
@@ -202,7 +202,7 @@ public abstract class ToolchainDiscoverer implements Named {
         });
         if (visitor != null)
             searchresult.explain(visitor);
-        return Optional.of(searchresult.getComponent());
+        return Optional.ofNullable(searchresult.getComponent());
     }
 
     public static List<File> systemPath(Project project, Function<String, String> composer) {

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2023.2.7"
+    version = "2023.2.8"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion


### PR DESCRIPTION
The option conversion wouldn't accept a null, but a compiler that can't be ran would result in a null metadata component.

Closes #43 