### PR TITLE
Move static variables to a root extension

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDiscoverer.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDiscoverer.java
@@ -224,8 +224,6 @@ public abstract class ToolchainDiscoverer implements Named {
 
             whichResult = os.toString().trim();
             tce.addWhichResult(tool, whichResult);
-        } else {
-            System.out.println("Using cache for " + tool);
         }
 
         return Arrays.stream(whichResult.split("\n"))

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDiscoverer.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDiscoverer.java
@@ -21,16 +21,16 @@ import org.gradle.internal.logging.text.DiagnosticsVisitor;
 import org.gradle.internal.os.OperatingSystem;
 import org.gradle.nativeplatform.toolchain.internal.SystemLibraries;
 import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.GccMetadata;
-import org.gradle.nativeplatform.toolchain.internal.gcc.metadata.GccMetadataProvider;
+import org.gradle.nativeplatform.toolchain.internal.metadata.CompilerMetaDataProvider;
+import org.gradle.nativeplatform.toolchain.internal.metadata.CompilerMetaDataProviderFactory;
 import org.gradle.platform.base.internal.toolchain.SearchResult;
 import org.gradle.process.ExecSpec;
-import org.gradle.process.internal.ExecActionFactory;
 import org.gradle.util.internal.VersionNumber;
 
 public abstract class ToolchainDiscoverer implements Named {
 
     private final String name;
-    private final GccMetadataProvider metadataProvider;
+    private final CompilerMetaDataProvider<GccMetadata> metadataProvider;
     private Optional<GccMetadata> metadataLazy;
     private final Provider<File> rootDir;
     private final Function<String, String> composer;
@@ -48,14 +48,14 @@ public abstract class ToolchainDiscoverer implements Named {
     }
 
     @Inject
-    public ToolchainDiscoverer(String name, ToolchainDescriptorBase descriptor, Provider<File> rootDir, Function<String, String> composer, ExecActionFactory execFactory, ProviderFactory providers) {
+    public ToolchainDiscoverer(String name, ToolchainDescriptorBase descriptor, Provider<File> rootDir, Function<String, String> composer, CompilerMetaDataProviderFactory metaDataProviderFactory, ProviderFactory providers) {
         this.name = name;
         this.rootDir = rootDir;
         this.composer = composer;
         this.metadataLazy = Optional.empty();
         this.descriptor = descriptor;
 
-        this.metadataProvider = GccMetadataProvider.forGcc(execFactory);
+        this.metadataProvider = metaDataProviderFactory.gcc();
     }
 
     private Optional<File> rootDirFile;
@@ -208,32 +208,40 @@ public abstract class ToolchainDiscoverer implements Named {
         return Optional.ofNullable(searchresult.getComponent());
     }
 
-    public static List<File> systemPath(Project project, Function<String, String> composer) {
+    public static List<File> systemPath(Project project, ToolchainRootExtension tce, Function<String, String> composer) {
         String tool = composer == null ? "g++" : composer.apply("gcc");
-        ByteArrayOutputStream os = new ByteArrayOutputStream();
-        ByteArrayOutputStream errStr = new ByteArrayOutputStream();
+        String whichResult = tce.getWhichResult(tool);
+        if (whichResult == null) {
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            ByteArrayOutputStream errStr = new ByteArrayOutputStream();
 
-        project.exec((ExecSpec spec) -> {
-            spec.commandLine(OperatingSystem.current().isWindows() ? "where.exe" : "which", tool);
-            spec.setStandardOutput(os);
-            spec.setErrorOutput(errStr);
-            spec.setIgnoreExitValue(true);
-        });
+            project.exec((ExecSpec spec) -> {
+                spec.commandLine(OperatingSystem.current().isWindows() ? "where.exe" : "which", tool);
+                spec.setStandardOutput(os);
+                spec.setErrorOutput(errStr);
+                spec.setIgnoreExitValue(true);
+            });
 
-        return Arrays.stream(os.toString().trim().split("\n"))
+            whichResult = os.toString().trim();
+            tce.addWhichResult(tool, whichResult);
+        } else {
+            System.out.println("Using cache for " + tool);
+        }
+
+        return Arrays.stream(whichResult.split("\n"))
                 .map(String::trim)
                 .filter(((Predicate<String>)String::isEmpty).negate())
                 .map((String path) -> { return new File(path).getParentFile().getParentFile(); })
                 .collect(Collectors.toList());
     }
 
-    public static ToolchainDiscovererProperty forSystemPath(Project project, ToolchainDescriptorBase descriptor, Function<String, String> composer) {
+    public static ToolchainDiscovererProperty forSystemPath(Project project, ToolchainRootExtension tce, ToolchainDescriptorBase descriptor, Function<String, String> composer) {
         ToolchainDiscovererProperty prop = project.getObjects().newInstance(ToolchainDiscovererProperty.class, "PathList");
 
         Provider<List<ToolchainDiscoverer>> p = project.provider(() -> {
             List<ToolchainDiscoverer> disc = new ArrayList<>();
             int i = 0;
-            for (File f : systemPath(project, composer)) {
+            for (File f : systemPath(project, tce, composer)) {
                 Provider<File> fp = project.provider(() -> f);
                 disc.add(ToolchainDiscoverer.createDiscoverer("Path" + (i++), descriptor, fp, composer, project));
             }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -59,7 +59,7 @@ public class ToolchainExtension {
                 descriptor.getToolchainPlatform().set(project.provider(() -> config.getOperatingSystem().get() + config.getArchitecture().get()));
                 toolchainDescriptors.add(descriptor);
 
-                descriptor.getDiscoverers().add(ToolchainDiscoverer.forSystemPath(project, descriptor, name -> {
+                descriptor.getDiscoverers().add(ToolchainDiscoverer.forSystemPath(project, rootExtension, descriptor, name -> {
                     String exeSuffix = OperatingSystem.current().isWindows() ? ".exe" : "";
                     return config.getCompilerPrefix().get() + name + exeSuffix;
                 }));

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -27,9 +27,15 @@ public class ToolchainExtension {
     public boolean registerPlatforms = true;
     public boolean registerReleaseBuildType = true;
     public boolean registerDebugBuildType = true;
+    private final ToolchainRootExtension rootExtension;
 
-    public ToolchainExtension(Project project) {
+    public ToolchainRootExtension getRootExtension() {
+        return rootExtension;
+    }
+
+    public ToolchainExtension(Project project, ToolchainRootExtension rootExtension) {
         this.project = project;
+        this.rootExtension = rootExtension;
 
         crossCompilers = project.container(CrossCompilerConfiguration.class, name -> {
             return project.getObjects().newInstance(CrossCompilerConfiguration.class, name);
@@ -67,7 +73,7 @@ public class ToolchainExtension {
     }
 
     public void setSinglePrintPerPlatform() {
-        ToolchainPlugin.singlePrintPerPlatform = true;
+        rootExtension.setSinglePrintPerPlatform();
         // ToolchainUtilExtension tcuExt = project.getExtensions().findByType(ToolchainUtilExtension.class);
         // if (tcuExt != null) {
         //     tcuExt.setSkipBinaryToolchainMissingWarning(true);

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
@@ -20,6 +20,7 @@ public class ToolchainPlugin implements Plugin<Project> {
         if (tcr == null) {
             tcr = project.getRootProject().getExtensions().create("toolchainsRootExtension", ToolchainRootExtension.class, project.getGradle());
         }
+        ToolchainRootExtension tcrf = tcr;
 
         ext = project.getExtensions().create("toolchainsPlugin", ToolchainExtension.class, project, tcr);
 
@@ -35,11 +36,13 @@ public class ToolchainPlugin implements Plugin<Project> {
         });
 
         ext.getToolchainDescriptors().all((ToolchainDescriptorBase desc) -> {
-            project.getTasks().register(desc.getInstallTaskName(), InstallToolchainTask.class, (InstallToolchainTask t) -> {
-                t.setGroup("Toolchains");
-                t.setDescription("Install Toolchain for " + desc.getName() + " if installers are available.");
-                t.setDescriptor(desc);
-            });
+            if (tcrf.registerInstallTask(desc.getInstallTaskName())) {
+                project.getTasks().register(desc.getInstallTaskName(), InstallToolchainTask.class, (InstallToolchainTask t) -> {
+                    t.setGroup("Toolchains");
+                    t.setDescription("Install Toolchain for " + desc.getName() + " if installers are available.");
+                    t.setDescriptor(desc);
+                });
+            }
         });
 
         project.getGradle().getTaskGraph().whenReady((TaskExecutionGraph graph) -> {

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRootExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRootExtension.java
@@ -1,0 +1,63 @@
+package edu.wpi.first.toolchain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.invocation.Gradle;
+import org.gradle.internal.logging.text.TreeFormatter;
+import org.gradle.internal.logging.text.StyledTextOutput;
+
+import edu.wpi.first.deployutils.log.ETLogger;
+import edu.wpi.first.deployutils.log.ETLoggerFactory;
+
+public class ToolchainRootExtension {
+    private boolean singlePrintPerPlatform = false;
+
+    public void setSinglePrintPerPlatform() {
+        singlePrintPerPlatform = true;
+    }
+
+    private final List<GccToolChain> missingToolChains = new ArrayList<>();
+
+    public void addMissingToolchain(GccToolChain toolchain) {
+        missingToolChains.add(toolchain);
+    }
+
+    @Inject
+    public ToolchainRootExtension(Gradle gradle) {
+        gradle.getTaskGraph().whenReady(graph -> {
+            List<String> skippedPlatforms = new ArrayList<>();
+            for (GccToolChain toolchain : missingToolChains) {
+                ToolchainDescriptorBase descriptor = toolchain.getDescriptor();
+                boolean installing = graph.getAllTasks().stream().anyMatch(t -> t instanceof InstallToolchainTask && ((InstallToolchainTask) t).getDescriptorName().equals(descriptor.getName()));
+                if (!installing) {
+                    ETLogger logger = ETLoggerFactory.INSTANCE.create(this.getClass().getSimpleName());
+                    TreeFormatter formatter = new TreeFormatter();
+                    descriptor.explain(formatter);
+                    logger.info(formatter.toString());
+
+                    boolean optional = descriptor.getOptional().get();
+                    if (optional) {
+                        if (!singlePrintPerPlatform || !skippedPlatforms.contains(descriptor.getName())) {
+                            skippedPlatforms.add(descriptor.getName());
+                            logger.logStyle("Skipping builds for " + descriptor.getName() + " (toolchain is marked optional)", StyledTextOutput.Style.Description);
+                        }
+                    } else if (toolchain.isUsed()) {
+                        logger.logError("=============================");
+                        logger.logErrorHead("No Toolchain Found for " + descriptor.getName());
+                        logger.logErrorHead("Run `./gradlew " + descriptor.getInstallTaskName() + "` to install one!");
+                        logger.logErrorHead("");
+                        logger.logErrorHead("You can ignore this error with -Ptoolchain-optional-" + descriptor.getName());
+                        logger.logErrorHead("For more information, run with `--info`");
+                        logger.logError("=============================");
+
+                        throw new GradleException("No Toolchain Found! Scroll up for more information.");
+                    }
+                }
+            }
+        });
+    }
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRootExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRootExtension.java
@@ -1,7 +1,9 @@
 package edu.wpi.first.toolchain;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 
@@ -15,6 +17,26 @@ import edu.wpi.first.deployutils.log.ETLoggerFactory;
 
 public class ToolchainRootExtension {
     private boolean singlePrintPerPlatform = false;
+
+    private final List<String> registeredInstallTasks = new ArrayList<>();
+
+    public boolean registerInstallTask(String name) {
+        if (registeredInstallTasks.contains(name)) {
+            return false;
+        }
+        registeredInstallTasks.add(name);
+        return true;
+    }
+
+    private final Map<String, String> whichResults = new HashMap<>();
+
+    public String getWhichResult(String tool) {
+        return whichResults.getOrDefault(tool, null);
+    }
+
+    public void addWhichResult(String tool, String value) {
+        whichResults.put(tool, value);
+    }
 
     public void setSinglePrintPerPlatform() {
         singlePrintPerPlatform = true;

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm32/Arm32ToolchainPlugin.java
@@ -26,7 +26,7 @@ public class Arm32ToolchainPlugin implements Plugin<Project> {
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
         opensdk = new OpenSdkToolchainBase(baseToolchainName, arm32Ext, project, Arm32ToolchainExtension.INSTALL_SUBDIR,
-                "raspi-bullseye", project.provider(() -> "armv6-bullseye-linux-gnueabihf"));
+                "raspi-bullseye", project.provider(() -> "armv6-bullseye-linux-gnueabihf"), toolchainExt.getRootExtension());
 
         CrossCompilerConfiguration configuration = project.getObjects().newInstance(CrossCompilerConfiguration.class, NativePlatforms.linuxarm32);
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/arm64/Arm64ToolchainPlugin.java
@@ -25,7 +25,7 @@ public class Arm64ToolchainPlugin implements Plugin<Project> {
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
         opensdk = new OpenSdkToolchainBase(baseToolchainName, arm64Ext, project, Arm64ToolchainExtension.INSTALL_SUBDIR,
-                "bullseye", project.provider(() -> "aarch64-bullseye-linux-gnu"));
+                "bullseye", project.provider(() -> "aarch64-bullseye-linux-gnu"), toolchainExt.getRootExtension());
 
         CrossCompilerConfiguration configuration = project.getObjects().newInstance(CrossCompilerConfiguration.class, NativePlatforms.linuxarm64);
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/opensdk/OpenSdkToolchainBase.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/opensdk/OpenSdkToolchainBase.java
@@ -15,6 +15,7 @@ import edu.wpi.first.toolchain.NativePlatforms;
 import edu.wpi.first.toolchain.ToolchainDescriptor;
 import edu.wpi.first.toolchain.ToolchainDiscoverer;
 import edu.wpi.first.toolchain.ToolchainPlugin;
+import edu.wpi.first.toolchain.ToolchainRootExtension;
 
 public class OpenSdkToolchainBase {
     private final String baseToolchainName;
@@ -23,15 +24,17 @@ public class OpenSdkToolchainBase {
     private final String installSubdir;
     private final String archiveSubDir;
     private final Provider<String> toolchainPrefix;
+    private final ToolchainRootExtension rootExtension;
 
     public OpenSdkToolchainBase(String baseToolchainName, OpenSdkToolchainExtension tcExt, Project project,
-            String installSubdir, String archiveSubdir, Provider<String> toolchainPrefix) {
+            String installSubdir, String archiveSubdir, Provider<String> toolchainPrefix, ToolchainRootExtension rootExtension) {
         this.baseToolchainName = baseToolchainName;
         this.tcExt = tcExt;
         this.project = project;
         this.installSubdir = installSubdir;
         this.archiveSubDir = archiveSubdir;
         this.toolchainPrefix = toolchainPrefix;
+        this.rootExtension = rootExtension;
     }
 
     private String toolchainRemoteFile() {
@@ -84,7 +87,7 @@ public class OpenSdkToolchainBase {
 
         // Discoverer order matters. They will be searched from top to bottom.
         descriptor.getDiscoverers().add(ToolchainDiscoverer.createProperty("GradleUserDir", descriptor, fp, this::composeTool, project));
-        descriptor.getDiscoverers().add(ToolchainDiscoverer.forSystemPath(project, descriptor, this::composeTool));
+        descriptor.getDiscoverers().add(ToolchainDiscoverer.forSystemPath(project, rootExtension, descriptor, this::composeTool));
 
         try {
             descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, fp, archiveSubDir));

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
@@ -38,7 +38,7 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
         });
 
         opensdk = new OpenSdkToolchainBase(baseToolchainName, roborioExt, project,
-                RoboRioToolchainExtension.INSTALL_SUBDIR, "roborio-academic", prefixProvider);
+                RoboRioToolchainExtension.INSTALL_SUBDIR, "roborio-academic", prefixProvider, toolchainExt.getRootExtension());
 
         CrossCompilerConfiguration configuration = project.getObjects().newInstance(CrossCompilerConfiguration.class, NativePlatforms.roborio);
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2023.4.1"
+    version = "2023.4.2"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2023.4.2"
+    version = "2023.5.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion


### PR DESCRIPTION
This allows us to get rid of the buildFinished listener, which is deprecated.