### PR TITLE
Fix cross compilers being able to use assembly

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
@@ -99,7 +99,7 @@ public class ToolchainRules extends RuleSource {
                             toolchain.getcCompiler().setExecutable(discoverer.toolName("gcc"));
                             toolchain.getCppCompiler().setExecutable(discoverer.toolName("g++"));
                             toolchain.getLinker().setExecutable(discoverer.toolName("g++"));
-                            toolchain.getAssembler().setExecutable(discoverer.toolName("as"));
+                            toolchain.getAssembler().setExecutable(discoverer.toolName("gcc"));
                             toolchain.getStaticLibArchiver().setExecutable(discoverer.toolName("ar"));
                         });
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2024.0.0"
+    version = "2024.1.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion


### PR DESCRIPTION
Gradle expects to call gcc with -x assembler rather then as directly