### PR TITLE
Add a basic vendor deps dependency mechanism

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ targetCompatibility = 11
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2024.1.0"
+    version = "2024.2.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/vendordeps/ConflictingVendorDependencyException.java
+++ b/src/main/java/edu/wpi/first/nativeutils/vendordeps/ConflictingVendorDependencyException.java
@@ -1,0 +1,8 @@
+package edu.wpi.first.nativeutils.vendordeps;
+
+public class ConflictingVendorDependencyException extends RuntimeException {
+    public ConflictingVendorDependencyException(String requestingUuid, String requiredUuid, String errorMessage) {
+        super("Conflicting Vendor Dependency " + requiredUuid + " for uuid " + requestingUuid + ". Reason: "
+                + errorMessage);
+    }
+}

--- a/src/main/java/edu/wpi/first/nativeutils/vendordeps/MissingRequiredVendorDependencyException.java
+++ b/src/main/java/edu/wpi/first/nativeutils/vendordeps/MissingRequiredVendorDependencyException.java
@@ -1,0 +1,8 @@
+package edu.wpi.first.nativeutils.vendordeps;
+
+public class MissingRequiredVendorDependencyException extends RuntimeException {
+    public MissingRequiredVendorDependencyException(String requestingUuid, String requiredUuid, String errorMessage) {
+        super("Missing Vendor Dependency " + requiredUuid + " for uuid " + requestingUuid + ". Reason: "
+                + errorMessage);
+    }
+}

--- a/src/main/java/edu/wpi/first/nativeutils/vendordeps/WPIVendorDepsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/vendordeps/WPIVendorDepsExtension.java
@@ -114,7 +114,6 @@ public abstract class WPIVendorDepsExtension {
 
     public void loadAll() {
         loadFrom(vendorFolder(project));
-        validateDependencies();
     }
 
     public void validateDependencies() {

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -2,7 +2,7 @@ import edu.wpi.first.toolchain.NativePlatforms
 
 plugins {
     id "cpp"
-    id "edu.wpi.first.NativeUtils" version "2024.0.1"
+    id "edu.wpi.first.NativeUtils" version "2024.1.0"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
One of the biggest requests for vendor deps has been handling transitive dependencies. Doing this properly is a hard problem. @JCaporuscio had a suggestion for building a basic setup, to allow enabling this for many of the cases without causing a massive amount of development pain.

The basic idea of this is each dependency can have a `requires` and a `conflictsWith` block. Each of these blocks contains an array of objects, each containing 3 elements.

uuid: The uuid that is required or that is conflicting
errorMessage: An error message to be displayed to the user
onlineUrl: The url to search for this vendor dep during installation (This isn't used by this PR, but will be used for the dep loader)

Once all dependencies have been loaded, the entire dep tree is searched. If a dependency has a `requires` dependency that _is not_ in the graph, the error message is printed. If a dependency has a `conflictsWith` dependency that _is_ in the graph, the error message is printed.

Because this is done after loading, N level transitive deps would be supported, as would (although why...) circular deps. 

This does nothing to ensure vendor deps are the correct year, or that versions match between transitive deps.

This new functionality is not automatically called. I want to move the automation into gradlerio to make configuration easier.