### PR TITLE
Add frcYear to vendor dep schema

### DIFF
--- a/src/main/java/edu/wpi/first/nativeutils/vendordeps/WPIVendorDepsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/vendordeps/WPIVendorDepsExtension.java
@@ -263,6 +263,7 @@ public abstract class WPIVendorDepsExtension {
         public String[] extraGroupIds;
         public String jsonUrl;
         public String fileName;
+        public String frcYear;
         public JavaArtifact[] javaDependencies;
         public JniArtifact[] jniDependencies;
         public CppArtifact[] cppDependencies;


### PR DESCRIPTION
We want to add a check for this, but I want that check to be in GradleRIO for configuration reasons. Add just to the schema.