### PR TITLE
Remove GCC and Clang toolchains from being found by default on windows

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -107,6 +107,16 @@ public class ToolchainExtension {
         }
     }
 
+    private boolean removeInvalidWindowsToolchains = true;
+
+    public void setRemoveInvalidWindowsToolchains(boolean remove) {
+        this.removeInvalidWindowsToolchains = remove;
+    }
+
+    public boolean isRemoveInvalidWindowsToolchains() {
+        return this.removeInvalidWindowsToolchains;
+    }
+
     public NamedDomainObjectContainer<ToolchainDescriptorBase> getToolchainDescriptors() {
         return toolchainDescriptors;
     }

--- a/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
@@ -388,4 +388,12 @@ public class NativeUtilsExtension {
   public void setSkipInstallPdb(boolean skip) {
     skipInstallPdb = skip;
   }
+
+  public void setRemoveInvalidWindowsToolchains(boolean remove) {
+    tcExt.setRemoveInvalidWindowsToolchains(remove);
+}
+
+  public boolean isRemoveInvalidWindowsToolchains() {
+      return tcExt.isRemoveInvalidWindowsToolchains();
+  }
 }


### PR DESCRIPTION
Theres an override if someone wants this behavior back.