### PR TITLE
Set DependentLoadFlags on windows binaries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2024.7.0"
+    version = "2024.8.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -43,7 +43,7 @@ public class WPINativeUtilsExtension {
         public final List<String> windowsCCompilerArgs = List.of("/FS", "/Zc:inline", "/D_CRT_SECURE_NO_WARNINGS");
         public final List<String> windowsReleaseCompilerArgs = List.of("/O2", "/MD");
         public final List<String> windowsDebugCompilerArgs = List.of("/Od", "/MDd");
-        public final List<String> windowsLinkerArgs = List.of("/DEBUG:FULL", "/PDBALTPATH:%_PDB%");
+        public final List<String> windowsLinkerArgs = List.of("/DEBUG:FULL", "/PDBALTPATH:%_PDB%", "/DEPENDENTLOADFLAG:0x1100");
         public final List<String> windowsReleaseLinkerArgs = List.of("/OPT:REF", "/OPT:ICF");
 
         public final String windowsSymbolArg = "/Zi";

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -2,7 +2,7 @@ import edu.wpi.first.toolchain.NativePlatforms
 
 plugins {
     id "cpp"
-    id "edu.wpi.first.NativeUtils" version "2024.7.0"
+    id "edu.wpi.first.NativeUtils" version "2024.8.0"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
DependentLoadFlags is something added in Windows 10 RS1 that allows modules to specify how they load their dll dependencies. By default, the application path, system32, and some other paths are searched. However, for our use this is kind of a pain, as when we extract libraries, they're not in the same path as the executable.

This PR adds the LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR flag, which lets us specify to load from our own dll directory first.