### PR TITLE
[vendordeps] handle null keys better

### DIFF
--- a/src/main/java/edu/wpi/first/nativeutils/vendordeps/VendorParsingError.java
+++ b/src/main/java/edu/wpi/first/nativeutils/vendordeps/VendorParsingError.java
@@ -1,0 +1,9 @@
+package edu.wpi.first.nativeutils.vendordeps;
+
+public enum VendorParsingError {
+    MissingName,
+    MissingCppDeps,
+    MissingJniDeps,
+    MissingJavaDeps,
+    NoMavenUrl,
+}

--- a/src/main/java/edu/wpi/first/nativeutils/vendordeps/VendorParsingException.java
+++ b/src/main/java/edu/wpi/first/nativeutils/vendordeps/VendorParsingException.java
@@ -1,0 +1,47 @@
+package edu.wpi.first.nativeutils.vendordeps;
+
+import org.gradle.tooling.BuildException;
+
+public class VendorParsingException extends Exception {
+    public VendorParsingException(String file, VendorParsingError error) {
+        switch (error) {
+            case NoMavenUrl:
+                System.err.println("The vendordep " + file + " is missing the required maven url.");
+                break;
+
+            case MissingCppDeps:
+                System.err.println("The vendordep " + file + " is missing the required C++ dependencies key.");
+                System.err.println("If you would not like to declare any Cpp deps use an empty list.");
+                break;
+
+            case MissingJniDeps:
+                System.err.println("The vendordep " + file + " is missing the required Jni dependencies key.");
+                System.err.println("If you would not like to declare any Jni deps use an empty list.");
+                break;
+
+            case MissingJavaDeps:
+                System.err.println("The vendordep " + file + " is missing the required Java dependencies key.");
+                System.err.println("If you would not like to declare any Java deps use an empty list.");
+                break;
+
+            default:
+                throw new BuildException(
+                        "Unhandled case in VendorParsingException. This is a bug and should be reported",
+                        new Exception());
+        }
+    }
+
+    // should only be called if we don't have access to a name yet
+    public VendorParsingException(VendorParsingError error) {
+        switch (error) {
+            case MissingName:
+                System.err.println("One of the vendordep files does not have a name");
+                break;
+
+            default:
+                throw new BuildException(
+                        "Unhandled case in VendorParsingException. This is a bug and should be reported",
+                        new Exception());
+        }
+    }
+}


### PR DESCRIPTION
Resolves [GradleRIO#727](https://github.com/wpilibsuite/GradleRIO/issues/727)

This reports errors when the vendor file is missing required keys. Instead of throwing a build exception directly we throw a custom exception that will be consumed by the BuildException when we call load.