### PR TITLE
Specify vendordep json file format

### DIFF
--- a/VendordepJsonSpecification.md
+++ b/VendordepJsonSpecification.md
@@ -1,0 +1,28 @@
+WPILib Vendor Dependency JSON File Format Specification
+===
+
+- version: 1.0
+
+Types
+---
+| Typename | JSON description |
+---
+| JavaArtifact | `{ groupId: String, ArtifactId: String, version: String }` |
+| JniArtifact | `{ groupId: String, ArtifactId: String, version: String, skipInvalidPlatforms: Boolean, isJar: Boolean, validPlatforms: String[] }` |
+| CppArtifact | `{ groupId: String, ArtifactId: String, version: String, libName: String, headerClassifier: String, sharedLibrary: Boolean, skipInvalidPlatforms: Boolean, binaryPlatforms: String[] }` |
+
+Keys
+---
+| Name | Type | Description | Optional |
+---
+| name | String | The name of the vendordep. | No. |
+| version | String | The version of the vendordep. | No. |
+| uuid | String | The unique identifier for the vendordep. Used to avoid replicating vendordeps in projects. | No. |
+| mavenUrls | String[] | An array of urls pointing to the root of the maven repository storing the vendordep. | No. |
+| extraGroupIds | String[] | | Yes. |
+| jsonUrl | String | The URL that the vendordep json file can be found at. | No. |
+| fileName | String | The name of the file this vendordep should be found in. | No. |
+| frcYear | String | The FRC year that this project should be compatible with | No. |
+| javaDependencies | JavaArtifact[] |
+| jniDependencies | JniArtifact[] |
+| cppDependencies | CppArtifact[] |


### PR DESCRIPTION
- [ ] Create accurate specification for current format
- [ ] Add tests to ensure that we don't silently break current format
- [ ] Update errors to point to the specification when it is useful