### PR TITLE
Bump macOS deployment target to 13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2024.7.0"
+    version = "2024.7.1"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -76,7 +76,7 @@ public class WPINativeUtilsExtension {
         public final List<String> linuxReleaseCompilerArgs = List.of("-O2");
         public final List<String> linuxDebugCompilerArgs = List.of("-O0");
 
-        public final String macMinimumVersionArg = "-mmacosx-version-min=12";
+        public final String macMinimumVersionArg = "-mmacosx-version-min=13";
 
         public final List<String> macCompilerArgs = List.of("-std=c++20", "-pedantic", "-fPIC", "-Wno-unused-parameter",
                 "-Wno-error=deprecated-enum-enum-conversion", "-Wno-missing-field-initializers",

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -2,7 +2,7 @@ import edu.wpi.first.toolchain.NativePlatforms
 
 plugins {
     id "cpp"
-    id "edu.wpi.first.NativeUtils" version "2024.7.0"
+    id "edu.wpi.first.NativeUtils" version "2024.7.1"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
macOS 12 is EOL in mid-October of 2024 based on when macOS 11 was dropped last year.