### PR TITLE
Set rpath on install_name on macOS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2025.0.0"
+    version = "2025.1.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/RpathRules.java
+++ b/src/main/java/edu/wpi/first/nativeutils/RpathRules.java
@@ -1,0 +1,21 @@
+package edu.wpi.first.nativeutils;
+
+import org.gradle.api.Task;
+import org.gradle.model.ModelMap;
+import org.gradle.model.RuleSource;
+import org.gradle.nativeplatform.SharedLibraryBinarySpec;
+import org.gradle.nativeplatform.tasks.LinkSharedLibrary;
+import org.gradle.platform.base.BinaryTasks;
+
+public class RpathRules extends RuleSource {
+  @BinaryTasks
+  public void createRpathSharedBinaryTasks(ModelMap<Task> tasks, SharedLibraryBinarySpec binary) {
+    if (!binary.getTargetPlatform().getOperatingSystem().isMacOsX()) {
+      return;
+    }
+
+    binary.getTasks().withType(LinkSharedLibrary.class, link -> {
+        link.getInstallName().set("@rpath/" + binary.getSharedLibraryFile().getName());
+    });
+  }
+}

--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtils.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtils.java
@@ -11,5 +11,7 @@ public class WPINativeUtils implements Plugin<Project> {
     NativeUtilsExtension nativeExt = project.getExtensions().getByType(NativeUtilsExtension.class);
 
     nativeExt.addWpiExtension();
+
+    project.getPluginManager().apply(RpathRules.class);
   }
 }

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -2,7 +2,7 @@ import edu.wpi.first.toolchain.NativePlatforms
 
 plugins {
     id "cpp"
-    id "edu.wpi.first.NativeUtils" version "2025.0.0"
+    id "edu.wpi.first.NativeUtils" version "2025.1.0"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
On macOS, in order to pick up rpath properly for downstream dependencies, the install name must be prefixed with rpath. Do that, so dependent libraries will be properly picked up. 