### PR TITLE
Add ability to resolve transitive dependencies for native libraries

### DIFF
--- a/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
@@ -94,6 +94,12 @@ public class NativeUtilsExtension {
     });
   }
 
+  private <T extends NativeDependency> void addNativeDependencyType(Class<T> cls, Object arg0, Object arg1) {
+    dependencyContainer.registerFactory(cls, name -> {
+      return objectFactory.newInstance(cls, name, arg0, arg1);
+    });
+  }
+
   @Inject
   public NativeUtilsExtension(Project project, ToolchainExtension tcExt) {
     this.project = project;
@@ -105,8 +111,8 @@ public class NativeUtilsExtension {
     });
 
     dependencyContainer = objectFactory.polymorphicDomainObjectContainer(NativeDependency.class);
-    addNativeDependencyType(WPIStaticMavenDependency.class, project);
-    addNativeDependencyType(WPISharedMavenDependency.class, project);
+    addNativeDependencyType(WPIStaticMavenDependency.class, project, dependencyContainer);
+    addNativeDependencyType(WPISharedMavenDependency.class, project, dependencyContainer);
     addNativeDependencyType(WPIHeaderOnlyMavenDependency.class, project);
 
     addNativeDependencyType(CombinedIgnoreMissingPlatformNativeDependency.class, dependencyContainer);

--- a/src/main/java/edu/wpi/first/nativeutils/dependencies/WPIStaticMavenDependency.java
+++ b/src/main/java/edu/wpi/first/nativeutils/dependencies/WPIStaticMavenDependency.java
@@ -10,15 +10,21 @@ import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.nativeplatform.BuildType;
 import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.api.NamedDomainObjectCollection;
+import org.gradle.api.provider.ListProperty;
 
 public abstract class WPIStaticMavenDependency extends WPIMavenDependency {
     public static final List<String> STATIC_MATCHERS = List.of("**/*.lib", "**/*.a");
     public static final List<String> EMPTY_LIST = List.of();
+    protected final NamedDomainObjectCollection<NativeDependency> dependencyCollection;
 
     @Inject
-    public WPIStaticMavenDependency(String name, Project project) {
+    public WPIStaticMavenDependency(String name, Project project, NamedDomainObjectCollection<NativeDependency> dependencyCollection) {
         super(name, project);
+        this.dependencyCollection = dependencyCollection;
     }
+    
+    public abstract ListProperty<String> getDependencies();
 
     @Override
     public Optional<ResolvedNativeDependency> resolveNativeDependency(NativePlatform platform, BuildType buildType, Optional<FastDownloadDependencySet> loaderDependencySet) {
@@ -40,6 +46,15 @@ public abstract class WPIStaticMavenDependency extends WPIMavenDependency {
 
         FileCollection linkFiles = getArtifactFiles(platformName + "static", buildTypeName, STATIC_MATCHERS, EMPTY_LIST, ArtifactType.LINK, loaderDependencySet);
         FileCollection runtimeFiles = getProject().files();
+        
+        List<String> dependencies = getDependencies().get();
+        for (String dep : dependencies) {
+            ResolvedNativeDependency resolved = dependencyCollection.getByName(dep).resolveNativeDependency(platform, buildType, loaderDependencySet).get();
+            headers = headers.plus(resolved.getIncludeRoots());
+            sources = sources.plus(resolved.getSourceRoots());
+            linkFiles = linkFiles.plus(resolved.getLinkFiles());
+            runtimeFiles = runtimeFiles.plus(resolved.getRuntimeFiles());
+        }
 
         resolvedDep = Optional.of(new ResolvedNativeDependency(headers, sources, linkFiles, runtimeFiles));
 


### PR DESCRIPTION
This provides the ability to hook up direct dependencies to known libraries, and then resolve them to a transitive list. This means that downstream users can say 

`nativeUtils.useRequiredLibrary(it, 'ntcore_shared')`, and it will automatically pull in `wpiutil_shared` and `wpinet_shared`. This make it easer to update things when new libraries are added, or if libraries are broken up into smaller chunks and brought together with a meta-library, as suggested [here](https://github.com/wpilibsuite/allwpilib/issues/6743).

I'm not a gradle whiz, so I'm throwing this up as a draft to start a discussion