### PR TITLE
Switch googletest to use artifacts from monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ nativeUtils.wpi.configureDependencies {
   wpiVersion = ""
   niLibVersion = ""
   opencvVersion = ""
-  googleTestVersion = ""
 }
 
 // The 6 below get the string representation of the main platforms

--- a/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -450,7 +450,7 @@ public class WPINativeUtilsExtension {
 
     private void registerStaticOnlyStandardDependency(
             ExtensiblePolymorphicDomainObjectContainer<NativeDependency> configs,
-            String name, Provider<String> groupId, String artifactId, Property<String> version) {
+            String name, String groupId, String artifactId, Property<String> version) {
         configs.register(name + "_static", WPIStaticMavenDependency.class, c -> {
             c.getGroupId().set(groupId);
             c.getArtifactId().set(artifactId);
@@ -562,13 +562,11 @@ public class WPINativeUtilsExtension {
 
         Provider<String> opencvYearGroup = provider
                 .provider(() -> "edu.wpi.first.thirdparty." + dependencyVersions.getOpencvYear().get() + ".opencv");
-        Provider<String> googleTestYearGroup = provider
-                .provider(() -> "edu.wpi.first.thirdparty." + dependencyVersions.getGoogleTestYear().get());
 
         registerStandardDependency(configs, "opencv", opencvYearGroup, "opencv-cpp",
                 dependencyVersions.getOpencvVersion());
-        registerStaticOnlyStandardDependency(configs, "googletest", googleTestYearGroup, "googletest",
-                dependencyVersions.getGoogleTestVersion());
+        registerStaticOnlyStandardDependency(configs, "googletest", "edu.wpi.first.thirdparty.googletest", "googletest-cpp",
+                wpiVersion);
 
         configs.register("wpilib_jni", AllPlatformsCombinedNativeDependency.class, c -> {
             ListProperty<String> d = c.getDependencies();


### PR DESCRIPTION
Closes #210 

Do not merge until we are ready to update gradlerio to 2025. This will break gradlerio. This will also break any vendors not pointing to newer wpilib artifacts.