### PR TITLE
Fix fakeplatform being stripped by -Ponly*, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ nativeUtils.wpi.configureDependencies {
   opencvVersion = ""
 }
 
-// The 6 below get the string representation of the main platforms
+// The 8 below get the string representation of the main platforms
 // For use comparing to binary.targetPlatform.name
 nativeUtils.wpi.platforms.roborio
 nativeUtils.wpi.platforms.linuxarm32
@@ -135,6 +135,8 @@ nativeUtils.wpi.platforms.systemcore
 nativeUtils.wpi.platforms.windowsx64
 nativeUtils.wpi.platforms.osxuniversal
 nativeUtils.wpi.platforms.linuxx64
+// `fakeplatform` (enabled using -Pusefakeplatform) forces gradle to
+// use platform-specific subdirectories when -Ponly* is specified
 nativeUtils.wpi.platforms.fakeplatform
 
 // An immutable list of all wpi platforms

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/NativePlatforms.java
@@ -11,6 +11,7 @@ public class NativePlatforms {
     public static final String systemcore = "linuxsystemcore";
     public static final String linuxarm32 = "linuxarm32";
     public static final String linuxarm64 = "linuxarm64";
+    public static final String fakeplatform = "fakeplatform";
 
     public static final String arm32arch = "arm32";
     public static final String arm64arch = "arm64";

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
@@ -193,7 +193,7 @@ public class ToolchainRules extends RuleSource {
             }
 
             if (ext.getProject().hasProperty("usefakeplatform")) {
-                NativePlatform fakePlatform = platforms.maybeCreate("fakeplatform", NativePlatform.class);
+                NativePlatform fakePlatform = platforms.maybeCreate(NativePlatforms.fakeplatform, NativePlatform.class);
                 fakePlatform.architecture("noarch");
             }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "edu.wpi.first"
-    version = "2025.12.3"
+    version = "2025.12.4"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/edu/wpi/first/nativeutils/NativeUtilsExtension.java
@@ -294,6 +294,9 @@ public class NativeUtilsExtension {
 
     if (!only) {
       platformsToConfigure.addAll(tmpList);
+    } else if (tmpList.contains(NativePlatforms.fakeplatform) && !platformsToConfigure.contains(NativePlatforms.fakeplatform)) {
+      // the user specified usefakeplatform, ensure that it is added
+      platformsToConfigure.add(NativePlatforms.fakeplatform);
     }
 
     if (!project.hasProperty("buildwinarm64") && NativePlatforms.desktopArch().equals("x86-64")) {

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -3,7 +3,7 @@ import edu.wpi.first.nativeutils.vendordeps.WPIVendorDepsPlugin
 
 plugins {
     id "cpp"
-    id "edu.wpi.first.NativeUtils" version "2025.12.3"
+    id "edu.wpi.first.NativeUtils" version "2025.12.4"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
This fixes NativeUtilsExtension by explicitly adding "fakeplatform" to the list of platforms to configure if the project sees a `-Ponly*` flag, provided "fakeplatform" hasn't already been added to the list.
This also updates the README to describe the purpose of fakeplatform and how to enable it.

This has been tested both with and without `-Ponly*` flags for native and linuxathena, and with and without `-Pusefakeplatform`, on Windows and Linux x86-64.