### PR TITLE
Use actual gradle user home directory for toolchains

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,17 +28,8 @@ jobs:
       run: ./gradlew publishToMavenLocal
     - name: Check output
       run: git --no-pager diff --exit-code HEAD
-    - name: InstallRioTC
-      run: ../../gradlew installRoboRioToolchain
-      working-directory: testing/cpp
-    - name: InstallArm32Tc
-      run: ../../gradlew installArm32Toolchain
-      working-directory: testing/cpp
-    - name: InstallArm64Tc
-      run: ../../gradlew installArm64Toolchain
-      working-directory: testing/cpp
-    - name: InstallSystemCoreTc
-      run: ../../gradlew installSystemCoreToolchain
+    - name: Install All Toolchains
+      run: ../../gradlew installRoboRioToolchain installArm32Toolchain installArm64Toolchain installSystemCoreToolchain
       working-directory: testing/cpp
     - name: Build Test
       run: ../../gradlew build

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/DefaultToolchainInstaller.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/DefaultToolchainInstaller.java
@@ -29,7 +29,7 @@ public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
     @Override
     public void install(Project project) {
         URL source = sourceProvider.get();
-        File cacheLoc = new File(ToolchainPlugin.gradleHome(), "cache");
+        File cacheLoc = new File(project.getGradle().getGradleUserHomeDir(), "cache");
         File dst = new File(cacheLoc, "download/" + source.getPath());
         dst.getParentFile().mkdirs();
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
@@ -75,12 +75,8 @@ public class ToolchainPlugin implements Plugin<Project> {
         //project.getPluginManager().apply(ToolchainsPlugin.class);
     }
 
-    public static File gradleHome() {
-        return new File(System.getProperty("user.home"), ".gradle");
-    }
-
-    public static File pluginHome() {
-        return new File(gradleHome(), "toolchains");
+    public static File pluginHome(Project project) {
+        return new File(project.getGradle().getGradleUserHomeDir(), "toolchains");
     }
 
 }

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/opensdk/OpenSdkToolchainBase.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/opensdk/OpenSdkToolchainBase.java
@@ -81,8 +81,8 @@ public class OpenSdkToolchainBase {
         return toolchainPrefix.get() + "-" + toolName + exeSuffix;
     }
 
-    public static File toolchainInstallLoc(String year, String installSubdir) {
-        return new File(ToolchainPlugin.pluginHome(), "frc/" + year + "/" + installSubdir);
+    public File toolchainInstallLoc(String year, String installSubdir) {
+        return new File(ToolchainPlugin.pluginHome(project), "frc/" + year + "/" + installSubdir);
     }
 
     public AbstractToolchainInstaller installerFor(OperatingSystem os, Provider<File> installDir, String subdir)

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm32/Arm32DownloadTest.groovy
@@ -12,6 +12,7 @@ import spock.lang.IgnoreIf
 @IgnoreIf({ !Boolean.valueOf(env['SPOCK_RUN_TOOLCHAINS']) })
 class Arm32DownloadTest extends Specification {
   @TempDir File testProjectDir
+  @TempDir File gradleUserHome
   File buildFile
   @Shared File toolchainDir
 
@@ -19,12 +20,6 @@ class Arm32DownloadTest extends Specification {
     buildFile = new File(testProjectDir, 'build.gradle')
   }
 
-  def setupSpec() {
-    String year = Arm32ToolchainExtension.TOOLCHAIN_VERSION.split("-")[0].toLowerCase();
-    toolchainDir = OpenSdkToolchainBase.toolchainInstallLoc(year, Arm32ToolchainExtension.INSTALL_SUBDIR);
-    def result = toolchainDir.deleteDir()  // Returns true if all goes well, false otherwise.
-    assert result
-  }
 
   def "Toolchain Can Download"() {
     given:
@@ -38,7 +33,7 @@ toolchainsPlugin.withCrossLinuxArm32()
     when:
     def result = GradleRunner.create()
                              .withProjectDir(testProjectDir)
-                             .withArguments('installArm32Toolchain', '--stacktrace')
+                             .withArguments('installArm32Toolchain', '--stacktrace', '-Dgradle.user.home=' + gradleUserHome)
                              .withPluginClasspath()
                              .build()
 

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm64/Arm64DownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/arm64/Arm64DownloadTest.groovy
@@ -12,18 +12,12 @@ import spock.lang.IgnoreIf
 @IgnoreIf({ !Boolean.valueOf(env['SPOCK_RUN_TOOLCHAINS']) })
 class Arm64DownloadTest extends Specification {
   @TempDir File testProjectDir
+  @TempDir File gradleUserHome
   File buildFile
   @Shared File toolchainDir
 
   def setup() {
     buildFile = new File(testProjectDir, 'build.gradle')
-  }
-
-  def setupSpec() {
-    String year = Arm64ToolchainExtension.TOOLCHAIN_VERSION.split("-")[0].toLowerCase();
-    toolchainDir = OpenSdkToolchainBase.toolchainInstallLoc(year, Arm64ToolchainExtension.INSTALL_SUBDIR);
-    def result = toolchainDir.deleteDir()  // Returns true if all goes well, false otherwise.
-    assert result
   }
 
   def "Toolchain Can Download"() {
@@ -38,7 +32,7 @@ toolchainsPlugin.withCrossLinuxArm64()
     when:
     def result = GradleRunner.create()
                              .withProjectDir(testProjectDir)
-                             .withArguments('installArm64Toolchain', '--stacktrace')
+                             .withArguments('installArm64Toolchain', '--stacktrace', '-Dgradle.user.home=' + gradleUserHome)
                              .withPluginClasspath()
                              .build()
 

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/roborio/RoborioDownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/roborio/RoborioDownloadTest.groovy
@@ -12,18 +12,12 @@ import spock.lang.IgnoreIf
 @IgnoreIf({ !Boolean.valueOf(env['SPOCK_RUN_TOOLCHAINS']) })
 class RoboRioDownloadTest extends Specification {
   @TempDir File testProjectDir
+  @TempDir File gradleUserHome
   File buildFile
   @Shared File toolchainDir
 
   def setup() {
     buildFile = new File(testProjectDir, 'build.gradle')
-  }
-
-  def setupSpec() {
-    String year = RoboRioToolchainExtension.TOOLCHAIN_VERSION.split("-")[0].toLowerCase();
-    toolchainDir = OpenSdkToolchainBase.toolchainInstallLoc(year, RoboRioToolchainExtension.INSTALL_SUBDIR);
-    def result = toolchainDir.deleteDir()  // Returns true if all goes well, false otherwise.
-    assert result
   }
 
   def "Toolchain Can Download"() {
@@ -38,7 +32,7 @@ toolchainsPlugin.withCrossRoboRIO()
     when:
     def result = GradleRunner.create()
                              .withProjectDir(testProjectDir)
-                             .withArguments('installRoboRioToolchain', '--stacktrace')
+                             .withArguments('installRoboRioToolchain', '--stacktrace', '-Dgradle.user.home=' + gradleUserHome)
                              .withPluginClasspath()
                              .build()
 

--- a/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/systemcore/SystemCoreDownloadTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/edu/wpi/first/toolchain/systemcore/SystemCoreDownloadTest.groovy
@@ -12,18 +12,12 @@ import spock.lang.IgnoreIf
 @IgnoreIf({ !Boolean.valueOf(env['SPOCK_RUN_TOOLCHAINS']) })
 class Arm64DownloadTest extends Specification {
   @TempDir File testProjectDir
+  @TempDir File gradleUserHome
   File buildFile
   @Shared File toolchainDir
 
   def setup() {
     buildFile = new File(testProjectDir, 'build.gradle')
-  }
-
-  def setupSpec() {
-    String year = SystemCoreToolchainExtension.TOOLCHAIN_VERSION.split("-")[0].toLowerCase();
-    toolchainDir = OpenSdkToolchainBase.toolchainInstallLoc(year, SystemCoreToolchainExtension.INSTALL_SUBDIR);
-    def result = toolchainDir.deleteDir()  // Returns true if all goes well, false otherwise.
-    assert result
   }
 
   def "Toolchain Can Download"() {
@@ -38,7 +32,7 @@ toolchainsPlugin.withCrossSystemCore()
     when:
     def result = GradleRunner.create()
                              .withProjectDir(testProjectDir)
-                             .withArguments('installSystemCoreToolchain', '--stacktrace')
+                             .withArguments('installSystemCoreToolchain', '--stacktrace', '-Dgradle.user.home=' + gradleUserHome)
                              .withPluginClasspath()
                              .build()
 


### PR DESCRIPTION
This change did expose an issue with the missing toolchain detection in ToolchainGraphBuildService when multiple toolchains are required during the CI integration test. The built in tests had to be changed to provide a new gradle user home for each test. Previously, they leaked their downloaded toolchains in ~/.gradle after the test was completed, so running the tests left all toolchains installed in ~/.gradle for the CI integration test to use. Now that the tests are isolated, the integration tests are run with no toolchains installed. The missing toolchain detection fails the build unless all toolchains are installed in a single invocation, even if the only task is installing one of the other toolchains.