### PR TITLE
Suppress unknown warnings in clang

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "org.wpilib"
-    version = "2027.4.1"
+    version = "2027.5.1"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
@@ -20,10 +20,6 @@ import org.gradle.nativeplatform.BuildTypeContainer;
 import org.gradle.nativeplatform.NativeBinarySpec;
 import org.gradle.nativeplatform.StaticLibraryBinarySpec;
 import org.gradle.nativeplatform.platform.NativePlatform;
-import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
-import org.gradle.nativeplatform.toolchain.Clang;
-import org.gradle.nativeplatform.toolchain.internal.ToolType;
-import org.gradle.nativeplatform.toolchain.internal.gcc.AbstractGccCompatibleToolChain;
 import org.gradle.platform.base.Platform;
 import org.gradle.platform.base.PlatformAwareComponentSpec;
 import org.gradle.platform.base.PlatformContainer;
@@ -315,16 +311,6 @@ public class NativeUtilsExtension {
     PlatformConfig config = this.getPlatformConfigs().findByName(targetName);
     if (config == null) {
       return;
-    }
-
-    if (binary.getToolChain() instanceof Clang clang) {
-      AbstractGccCompatibleToolChain tc = (AbstractGccCompatibleToolChain)clang;
-      var version = tc.select((NativePlatformInternal)binary.getTargetPlatform()).getCompilerMetadata(ToolType.C_COMPILER).getVersion();
-      if (version.getMajor() < 20) {
-        binary.getcCompiler().getArgs().add("-Wno-fixed-enum-extension");
-      } else {
-        binary.getcCompiler().getArgs().add("-Wno-c23-extensions");
-      }
     }
 
     boolean isDebug = binary.getBuildType().getName().contains("debug");

--- a/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
@@ -20,6 +20,10 @@ import org.gradle.nativeplatform.BuildTypeContainer;
 import org.gradle.nativeplatform.NativeBinarySpec;
 import org.gradle.nativeplatform.StaticLibraryBinarySpec;
 import org.gradle.nativeplatform.platform.NativePlatform;
+import org.gradle.nativeplatform.platform.internal.NativePlatformInternal;
+import org.gradle.nativeplatform.toolchain.Clang;
+import org.gradle.nativeplatform.toolchain.internal.ToolType;
+import org.gradle.nativeplatform.toolchain.internal.gcc.AbstractGccCompatibleToolChain;
 import org.gradle.platform.base.Platform;
 import org.gradle.platform.base.PlatformAwareComponentSpec;
 import org.gradle.platform.base.PlatformContainer;
@@ -311,6 +315,16 @@ public class NativeUtilsExtension {
     PlatformConfig config = this.getPlatformConfigs().findByName(targetName);
     if (config == null) {
       return;
+    }
+
+    if (binary.getToolChain() instanceof Clang clang) {
+      AbstractGccCompatibleToolChain tc = (AbstractGccCompatibleToolChain)clang;
+      var version = tc.select((NativePlatformInternal)binary.getTargetPlatform()).getCompilerMetadata(ToolType.C_COMPILER).getVersion();
+      if (version.getMajor() < 20) {
+        binary.getcCompiler().getArgs().add("-Wno-fixed-enum-extension");
+      } else {
+        binary.getcCompiler().getArgs().add("-Wno-c23-extensions");
+      }
     }
 
     boolean isDebug = binary.getBuildType().getName().contains("debug");

--- a/src/main/java/org/wpilib/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/WPINativeUtilsExtension.java
@@ -85,7 +85,7 @@ public class WPINativeUtilsExtension {
                 "-Wno-unused-private-field", "-Wno-unused-const-variable", "-Wno-error=c11-extensions", "-pthread",
                 "-Wno-deprecated-anon-enum-enum-conversion");
         public final List<String> macCCompilerArgs = List.of("-pedantic", "-fPIC", "-Wno-unused-parameter",
-                "-Wno-missing-field-initializers", "-Wno-unused-private-field", "-Wno-fixed-enum-extension");
+                "-Wno-missing-field-initializers", "-Wno-unused-private-field");
         public final List<String> macObjcppCompilerArgs = List.of("-std=c++20", "-stdlib=libc++", "-fobjc-weak",
                 "-fobjc-arc", "-fPIC");
         public final List<String> macObjcCompilerArgs = List.of("-fobjc-weak", "-fobjc-arc", "-fPIC");

--- a/src/main/java/org/wpilib/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/WPINativeUtilsExtension.java
@@ -85,7 +85,7 @@ public class WPINativeUtilsExtension {
                 "-Wno-unused-private-field", "-Wno-unused-const-variable", "-Wno-error=c11-extensions", "-pthread",
                 "-Wno-deprecated-anon-enum-enum-conversion");
         public final List<String> macCCompilerArgs = List.of("-pedantic", "-fPIC", "-Wno-unused-parameter",
-                "-Wno-missing-field-initializers", "-Wno-unused-private-field");
+                "-Wno-missing-field-initializers", "-Wno-unused-private-field", "-Wno-fixed-enum-extension", "-Wno-c23-extensions", "-Wno-unknown-warning-option");
         public final List<String> macObjcppCompilerArgs = List.of("-std=c++20", "-stdlib=libc++", "-fobjc-weak",
                 "-fobjc-arc", "-fPIC");
         public final List<String> macObjcCompilerArgs = List.of("-fobjc-weak", "-fobjc-arc", "-fPIC");

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -3,7 +3,7 @@ import org.wpilib.nativeutils.vendordeps.WPIVendorDepsPlugin
 
 plugins {
     id "cpp"
-    id "org.wpilib.NativeUtils" version "2027.4.1"
+    id "org.wpilib.NativeUtils" version "2027.5.1"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
Cleaner then the alternative, and with apple clange now at 21 we need to do this.