### PR TITLE
Update dependencies to reflect how they are published

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ nativeUtils.addWpiNativeUtils()
 // wpilib and driver. They still need to manually be added to individual
 // components. These just add to the back end
 nativeUtils.wpi.configureDependencies {
-  // Thse are the 6 separate versions used for wpi
+  // These are the 3 separate versions used for wpi
   // deps. They should be kept in sync.
   wpiVersion = ""
-  niLibVersion = ""
+  mrcLibVersion = ""
   opencvVersion = ""
 }
 

--- a/src/main/java/org/wpilib/nativeutils/WPINativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/WPINativeUtilsExtension.java
@@ -263,12 +263,6 @@ public class WPINativeUtilsExtension {
         public abstract Property<String> getMrcLibVersion();
 
         public abstract Property<String> getOpencvVersion();
-
-        public abstract Property<String> getGoogleTestVersion();
-
-        public abstract Property<String> getWpimathVersion();
-
-        public abstract Property<String> getImguiVersion();
     }
 
     private void addPlatformReleaseSymbolGeneration(String platform) {
@@ -433,14 +427,9 @@ public class WPINativeUtilsExtension {
             return;
         }
         dependencyVersions = objects.newInstance(DependencyVersions.class);
-
         dependencyVersions.getWpiVersion().set("-1");
         dependencyVersions.getMrcLibVersion().set("-1");
         dependencyVersions.getOpencvVersion().set("-1");
-        dependencyVersions.getGoogleTestVersion().set("-1");
-
-        dependencyVersions.getWpimathVersion().set("-1");
-        dependencyVersions.getImguiVersion().set("-1");
 
         dependencies.execute(dependencyVersions);
         versions = dependencyVersions;
@@ -464,7 +453,7 @@ public class WPINativeUtilsExtension {
 
         registerStandardDependency(configs, "opencv", "org.wpilib.thirdparty.opencv", "opencv-cpp",
                 dependencyVersions.getOpencvVersion());
-        registerStaticOnlyStandardDependency(configs, "googletest", "edu.wpi.first.thirdparty.googletest",
+        registerStaticOnlyStandardDependency(configs, "googletest", "org.wpilib.thirdparty.googletest",
                 "googletest-cpp",
                 wpiVersion);
 


### PR DESCRIPTION
Removes a bunch of versions that are not longer used, updates GoogleTest group ID.