### PR TITLE
Directly extract toolchain to install location

### DIFF
--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/DefaultToolchainInstaller.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/DefaultToolchainInstaller.java
@@ -6,14 +6,17 @@ import org.gradle.api.Project;
 import org.gradle.api.file.ArchiveOperations;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.file.DeleteSpec;
+import org.gradle.api.file.FileCopyDetails;
 import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
+import org.gradle.api.file.RelativePath;
 import org.gradle.api.provider.Provider;
 import org.gradle.internal.os.OperatingSystem;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
 
 import javax.inject.Inject;
@@ -23,7 +26,6 @@ public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
     private OperatingSystem os;
     private Provider<URL> sourceProvider;
     private Provider<File> installDirProvider;
-    private String subdir;
     private final File gradleUserHomeDir;
     private final DownloadAction downloadAction;
     private final FileSystemOperations fileSystemOperations;
@@ -33,7 +35,6 @@ public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
         public OperatingSystem os;
         public Provider<URL> sourceProvider;
         public Provider<File> installDirProvider;
-        public String subdir;
         public Project project;
     }
 
@@ -42,7 +43,6 @@ public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
         this.os = options.os;
         this.sourceProvider = options.sourceProvider;
         this.installDirProvider = options.installDirProvider;
-        this.subdir = options.subdir;
         this.gradleUserHomeDir = options.project.getGradle().getGradleUserHomeDir();
         downloadAction = new DownloadAction(options.project);
         this.fileSystemOperations = fileSystemOperations;
@@ -76,27 +76,6 @@ public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
         }
 
         System.out.println("Extracting...");
-        File extractDir = new File(cacheLoc, "extract/");
-        if (extractDir.exists()) {
-            fileSystemOperations.delete((DeleteSpec d) -> {
-                d.delete(extractDir);
-            });
-        }
-        extractDir.mkdirs();
-
-        fileSystemOperations.copy((CopySpec c) -> {
-            FileTree tree;
-            if (dst.getName().endsWith(".tar.gz") || dst.getName().endsWith(".tgz")) {
-                tree = archiveOperations.tarTree(archiveOperations.gzip(dst));
-            } else {
-                throw new GradleException("Don't know how to extract file type: " + dst.getName());
-            }
-            System.out.println(tree);
-            c.from(tree);
-            c.into(extractDir);
-        });
-
-        System.out.println("Copying...");
         File installDir = installDirProvider.get();
         if (installDir.exists()) {
             fileSystemOperations.delete((DeleteSpec d) -> {
@@ -106,10 +85,19 @@ public class DefaultToolchainInstaller extends AbstractToolchainInstaller {
         installDir.mkdirs();
 
         fileSystemOperations.copy((CopySpec c) -> {
-            c.from(new File(extractDir, subdir));
+            FileTree tree;
+            if (dst.getName().endsWith(".tar.gz") || dst.getName().endsWith(".tgz")) {
+                tree = archiveOperations.tarTree(archiveOperations.gzip(dst));
+            } else {
+                throw new GradleException("Don't know how to extract file type: " + dst.getName());
+            }
+            System.out.println(tree);
+            c.from(tree).eachFile((FileCopyDetails fcd) -> {
+                String[] segments = fcd.getRelativePath().getSegments();
+                fcd.setRelativePath(new RelativePath(true, Arrays.copyOfRange(segments, 1, segments.length)));
+            });
             c.into(installDir);
         });
-
         System.out.println("Done! Installed to: " + installDir.getAbsolutePath());
     }
 

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/arm64/Arm64ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/arm64/Arm64ToolchainPlugin.java
@@ -38,7 +38,6 @@ public class Arm64ToolchainPlugin implements Plugin<Project> {
         options.tcExt = arm64Ext;
         options.project = project;
         options.installSubdir = Arm64ToolchainExtension.INSTALL_SUBDIR;
-        options.archiveSubDir = "trixie";
         options.toolchainPrefix = project.provider(() -> "aarch64-trixie-linux-gnu");
         options.rootExtension = toolchainExt.getToolchainGraphService();
 

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/opensdk/OpenSdkToolchainBase.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/opensdk/OpenSdkToolchainBase.java
@@ -28,7 +28,6 @@ public class OpenSdkToolchainBase {
     private final OpenSdkToolchainExtension tcExt;
     private final Project project;
     private final String installSubdir;
-    private final String archiveSubDir;
     private final Provider<String> toolchainPrefix;
     private final ToolchainGraphBuildService rootExtension;
     private final ExecOperations operations;
@@ -39,7 +38,6 @@ public class OpenSdkToolchainBase {
         public OpenSdkToolchainExtension tcExt;
         public Project project;
         public String installSubdir;
-        public String archiveSubDir;
         public Provider<String> toolchainPrefix;
         public ToolchainGraphBuildService rootExtension;
     }
@@ -50,7 +48,6 @@ public class OpenSdkToolchainBase {
         this.tcExt = options.tcExt;
         this.project = options.project;
         this.installSubdir = options.installSubdir;
-        this.archiveSubDir = options.archiveSubDir;
         this.toolchainPrefix = options.toolchainPrefix;
         this.rootExtension = options.rootExtension;
         this.operations = operations;
@@ -99,13 +96,12 @@ public class OpenSdkToolchainBase {
         return new File(ToolchainPlugin.pluginHome(project), "first/" + year + "/" + installSubdir);
     }
 
-    public AbstractToolchainInstaller installerFor(OperatingSystem os, Provider<File> installDir, String subdir)
+    public AbstractToolchainInstaller installerFor(OperatingSystem os, Provider<File> installDir)
             throws MalformedURLException {
                 ToolchainInstallerOptions options = new ToolchainInstallerOptions();
                 options.os = os;
                 options.sourceProvider = project.provider(this::toolchainDownloadUrl);
                 options.installDirProvider = installDir;
-                options.subdir = subdir;
                 options.project = project;
                 return objectFactory.newInstance(DefaultToolchainInstaller.class, options);
     }
@@ -124,9 +120,9 @@ public class OpenSdkToolchainBase {
                 .add(ToolchainDiscoverer.forSystemPath(project, rootExtension, descriptor, this::composeTool, operations));
 
         try {
-            descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, fp, archiveSubDir));
-            descriptor.getInstallers().add(installerFor(OperatingSystem.WINDOWS, fp, archiveSubDir));
-            descriptor.getInstallers().add(installerFor(OperatingSystem.MAC_OS, fp, archiveSubDir));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.LINUX, fp));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.WINDOWS, fp));
+            descriptor.getInstallers().add(installerFor(OperatingSystem.MAC_OS, fp));
         } catch (MalformedURLException e) {
             throw new GradleException("Malformed Toolchain URL", e);
         }

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/systemcore/SystemCoreToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/systemcore/SystemCoreToolchainPlugin.java
@@ -46,7 +46,6 @@ public class SystemCoreToolchainPlugin implements Plugin<Project> {
         options.tcExt = systemcoreExt;
         options.project = project;
         options.installSubdir = SystemCoreToolchainExtension.INSTALL_SUBDIR;
-        options.archiveSubDir = "systemcore";
         options.toolchainPrefix = project.provider(() -> "aarch64-systemcore2027-linux-gnu");
         options.rootExtension = toolchainExt.getToolchainGraphService();
 


### PR DESCRIPTION
This saves space by not leaving behind an entire copy of the toolchain and skips a copy step (which is only a few seconds on my machine, but might be more on slower I/O).