### PR TITLE
Add things needed to make mrclib work again in allwpilib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "org.wpilib"
-    version = "2027.8.1"
+    version = "2027.8.2"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/org/wpilib/nativeutils/dependencies/WPIHeaderOnlyMavenDependency.java
+++ b/src/main/java/org/wpilib/nativeutils/dependencies/WPIHeaderOnlyMavenDependency.java
@@ -7,6 +7,7 @@ import javax.inject.Inject;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.nativeplatform.BuildType;
 import org.gradle.nativeplatform.platform.NativePlatform;
 
@@ -35,5 +36,5 @@ public abstract class WPIHeaderOnlyMavenDependency extends WPIMavenDependency {
         return resolvedDep;
     }
 
-    public abstract Property<Boolean> getSkipAtRuntime();
+    public abstract SetProperty<String> getSkipAtRuntimePlatforms();
 }

--- a/src/main/java/org/wpilib/nativeutils/dependencies/WPISharedMavenDependency.java
+++ b/src/main/java/org/wpilib/nativeutils/dependencies/WPISharedMavenDependency.java
@@ -10,6 +10,7 @@ import javax.inject.Inject;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Property;
+import org.gradle.api.provider.SetProperty;
 import org.gradle.nativeplatform.BuildType;
 import org.gradle.nativeplatform.platform.NativePlatform;
 
@@ -38,6 +39,9 @@ public abstract class WPISharedMavenDependency extends WPIMavenDependency {
         }
 
         String buildTypeName = buildType.getName();
+        if (getNoDebugSplit().getOrElse(false)) {
+            buildTypeName = "release";
+        }
 
         FileCollection headers = getArtifactRoots(getHeaderClassifier().getOrElse(null), ArtifactType.HEADERS, loaderDependencySet);
         FileCollection sources = getArtifactRoots(getSourceClassifier().getOrElse(null), ArtifactType.SOURCES, loaderDependencySet);
@@ -52,7 +56,8 @@ public abstract class WPISharedMavenDependency extends WPIMavenDependency {
         FileCollection linkFiles = getArtifactFiles(platformName, buildTypeName, SHARED_MATCHERS, sharedExcludes, ArtifactType.LINK, loaderDependencySet);
 
         FileCollection runtimeFiles;
-        if (getSkipAtRuntime().getOrElse(false)) {
+        Set<String> skipAtRuntimePlatforms = getSkipAtRuntimePlatforms().getOrNull();
+        if (skipAtRuntimePlatforms != null && skipAtRuntimePlatforms.contains(platformName)) {
             runtimeFiles = getProject().files();
         } else {
             runtimeFiles = getArtifactFiles(platformName, buildTypeName, RUNTIME_MATCHERS, RUNTIME_EXCLUDES, ArtifactType.RUNTIME, loaderDependencySet);
@@ -64,5 +69,7 @@ public abstract class WPISharedMavenDependency extends WPIMavenDependency {
         return resolvedDep;
     }
 
-    public abstract Property<Boolean> getSkipAtRuntime();
+    public abstract SetProperty<String> getSkipAtRuntimePlatforms();
+
+    public abstract Property<Boolean> getNoDebugSplit();
 }

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -3,7 +3,7 @@ import org.wpilib.nativeutils.vendordeps.WPIVendorDepsPlugin
 
 plugins {
     id "cpp"
-    id "org.wpilib.NativeUtils" version "2027.8.1"
+    id "org.wpilib.NativeUtils" version "2027.8.2"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
35ed343ceb5708f0c60c1659f9065bc4c93ce34c removed too much, so to use newer version of native utils, we need at least this much added back.