### PR TITLE
Force cross compiler to be required if using `-Ponly*`

### DIFF
--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/arm64/Arm64ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/arm64/Arm64ToolchainPlugin.java
@@ -49,7 +49,11 @@ public class Arm64ToolchainPlugin implements Plugin<Project> {
         configuration.getArchitecture().set("arm64");
         configuration.getOperatingSystem().set("linux");
         configuration.getCompilerPrefix().set("");
-        configuration.getOptional().convention(true);
+        if (project.hasProperty("onlylinuxarm64")) {
+          configuration.getOptional().convention(false);
+        } else {
+          configuration.getOptional().convention(true);
+        }
 
         ToolchainDescriptor descriptor = new ToolchainDescriptor(
                 project,

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/systemcore/SystemCoreToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/systemcore/SystemCoreToolchainPlugin.java
@@ -56,7 +56,11 @@ public class SystemCoreToolchainPlugin implements Plugin<Project> {
         configuration.getArchitecture().set("arm64");
         configuration.getOperatingSystem().set("linux");
         configuration.getCompilerPrefix().set("");
-        configuration.getOptional().convention(true);
+        if (project.hasProperty("onlylinuxsystemcore")) {
+          configuration.getOptional().convention(false);
+        } else {
+          configuration.getOptional().convention(true);
+        }
 
         ToolchainDescriptor descriptor = new ToolchainDescriptor(
                 project,


### PR DESCRIPTION
Doesn't cover the case where you skip adding `withCrossLinuxArm64`, etc. I couldn't fix that case. Closes #21.