### PR TITLE
Add support for grabbing an on disk dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ nativeUtils {
       staticPlatforms << ""
     }
   }
+  // Add a dependency using files that are already on disk. The map keys are
+  // native platform names, and the values are paths to link/runtime files.
+  // Platforms omitted from either map use this dependency as header-only.
+  nativeDependencyContainer {
+    create("localLibrary", org.wpilib.nativeutils.dependencies.WPIOnDiskDependency) {
+      headers = project.layout.projectDirectory.dir("path/to/include")
+      buildDependencies.put("linuxx64", ["path/to/liblocal.a"])
+      runtimeDependencies.put("linuxx64", ["path/to/liblocal.so"])
+    }
+  }
   // Add
   combinedDependencyConfigs {
     combinedName {

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "org.wpilib"
-    version = "2027.10.0"
+    version = "2027.11.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
@@ -33,6 +33,7 @@ import org.wpilib.nativeutils.dependencies.DelegatedDependencySet;
 import org.wpilib.nativeutils.dependencies.FastDownloadDependencySet;
 import org.wpilib.nativeutils.dependencies.NativeDependency;
 import org.wpilib.nativeutils.dependencies.WPIHeaderOnlyMavenDependency;
+import org.wpilib.nativeutils.dependencies.WPIOnDiskDependency;
 import org.wpilib.nativeutils.dependencies.WPISharedMavenDependency;
 import org.wpilib.nativeutils.dependencies.WPIStaticMavenDependency;
 import org.wpilib.nativeutils.exports.DefaultExportsConfig;
@@ -107,6 +108,7 @@ public class NativeUtilsExtension {
     addNativeDependencyType(WPIStaticMavenDependency.class, project);
     addNativeDependencyType(WPISharedMavenDependency.class, project);
     addNativeDependencyType(WPIHeaderOnlyMavenDependency.class, project);
+    addNativeDependencyType(WPIOnDiskDependency.class, project);
 
     addNativeDependencyType(CombinedIgnoreMissingPlatformNativeDependency.class, dependencyContainer);
     addNativeDependencyType(AllPlatformsCombinedNativeDependency.class, dependencyContainer);

--- a/src/main/java/org/wpilib/nativeutils/dependencies/WPIOnDiskDependency.java
+++ b/src/main/java/org/wpilib/nativeutils/dependencies/WPIOnDiskDependency.java
@@ -1,0 +1,86 @@
+package org.wpilib.nativeutils.dependencies;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.gradle.api.Project;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
+import org.gradle.api.provider.MapProperty;
+import org.gradle.nativeplatform.BuildType;
+import org.gradle.nativeplatform.platform.NativePlatform;
+
+/**
+ * A native dependency whose files are already available on disk.
+ *
+ * <p>The keys in {@link #getBuildDependencies()} and
+ * {@link #getRuntimeDependencies()} are native platform names. Platforms not
+ * present in either map are treated as header-only platforms. If both maps
+ * are empty, the dependency is header-only on every platform.</p>
+ */
+public abstract class WPIOnDiskDependency implements NativeDependency {
+    private final String name;
+    private final Project project;
+
+    private final Map<NativePlatform, Map<BuildType, Optional<ResolvedNativeDependency>>> resolvedDependencies = new HashMap<>();
+
+    @Inject
+    public WPIOnDiskDependency(String name, Project project) {
+        this.name = name;
+        this.project = project;
+        getBuildDependencies().convention(Map.of());
+        getRuntimeDependencies().convention(Map.of());
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * The directory containing the dependency's headers.
+     */
+    public abstract DirectoryProperty getHeaders();
+
+    /**
+     * Platform names mapped to files needed while linking the dependency.
+     */
+    public abstract MapProperty<String, List<String>> getBuildDependencies();
+
+    /**
+     * Platform names mapped to files that must be available when running the
+     * application.
+     */
+    public abstract MapProperty<String, List<String>> getRuntimeDependencies();
+
+    @Override
+    public Optional<ResolvedNativeDependency> resolveNativeDependency(NativePlatform platform, BuildType buildType,
+            Optional<FastDownloadDependencySet> loaderDependencySet) {
+        Map<BuildType, Optional<ResolvedNativeDependency>> buildTypeMap = resolvedDependencies.get(platform);
+        if (buildTypeMap != null && buildTypeMap.containsKey(buildType)) {
+            return buildTypeMap.get(buildType);
+        }
+
+        Map<String, List<String>> buildDependencies = getBuildDependencies().get();
+        Map<String, List<String>> runtimeDependencies = getRuntimeDependencies().get();
+        String platformName = platform.getName();
+
+        FileCollection headers = getHeaders().isPresent() ? project.files(getHeaders()) : project.files();
+        FileCollection sources = project.files();
+        FileCollection linkFiles = project.files(buildDependencies.getOrDefault(platformName, List.of()));
+        FileCollection runtimeFiles = project.files(runtimeDependencies.getOrDefault(platformName, List.of()));
+
+        Optional<ResolvedNativeDependency> resolvedDependency = Optional
+                .of(new ResolvedNativeDependency(headers, sources, linkFiles, runtimeFiles));
+        if (buildTypeMap == null) {
+            buildTypeMap = new HashMap<>();
+            resolvedDependencies.put(platform, buildTypeMap);
+        }
+        buildTypeMap.put(buildType, resolvedDependency);
+        return resolvedDependency;
+    }
+}

--- a/src/test/groovy/org/wpilib/nativeutils/NativeUtilsPluginInitializationTest.groovy
+++ b/src/test/groovy/org/wpilib/nativeutils/NativeUtilsPluginInitializationTest.groovy
@@ -31,4 +31,39 @@ class NativeUtilsPluginInitializationTest extends Specification {
     then:
     result.task(':tasks').outcome == SUCCESS
   }
+
+  def "On disk dependencies can be configured"() {
+    given:
+    buildFile << """plugins {
+  id 'cpp'
+  id 'org.wpilib.NativeUtils'
+}
+
+def localDependency = nativeUtils.nativeDependencyContainer.create(
+    'localLibrary', org.wpilib.nativeutils.dependencies.WPIOnDiskDependency)
+localDependency.headers = layout.projectDirectory.dir('include')
+localDependency.buildDependencies.put('linuxx64', ['lib/liblocal.a'])
+localDependency.runtimeDependencies.put('linuxx64', ['runtime/liblocal.so'])
+
+tasks.register('verifyOnDiskDependency') {
+  doLast {
+    assert nativeUtils.getNativeDependencyTypeClass('WPIOnDiskDependency') ==
+        org.wpilib.nativeutils.dependencies.WPIOnDiskDependency
+    assert localDependency.headers.get().asFile == file('include')
+    assert localDependency.buildDependencies.get().linuxx64 == ['lib/liblocal.a']
+    assert localDependency.runtimeDependencies.get().linuxx64 == ['runtime/liblocal.so']
+  }
+}
+"""
+
+    when:
+    def result = GradleRunner.create()
+                             .withProjectDir(testProjectDir)
+                             .withArguments('verifyOnDiskDependency', '--stacktrace')
+                             .withPluginClasspath()
+                             .build()
+
+    then:
+    result.task(':verifyOnDiskDependency').outcome == SUCCESS
+  }
 }

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -3,7 +3,7 @@ import org.wpilib.nativeutils.vendordeps.WPIVendorDepsPlugin
 
 plugins {
     id "cpp"
-    id "org.wpilib.NativeUtils" version "2027.10.0"
+    id "org.wpilib.NativeUtils" version "2027.11.0"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
Useful in mrclib development, where maven isn't the primary packaging method