### PR TITLE
Force use of GCC 14 on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@
 
 ```
 nativeUtils {
+  // Linux desktop builds use gcc-14/g++-14 by default to match the WPILib
+  // package build environment. Set false to use Gradle's normal toolchain
+  // selection instead.
+  requireVersionedLinuxGcc = true
+  // Or keep the override enabled and point it at another compatible GCC pair.
+  linuxCCompilerExecutable = "gcc-14"
+  linuxCppCompilerExecutable = "g++-14"
+
   platformConfigs {
     linuxathena {
       // The platform path for archives. Must be set
@@ -175,6 +183,9 @@ toolchainsPlugin {
   registerPlatforms = true
   registerReleaseBuildType = true
   registerDebugBuildType = true
+  requireVersionedLinuxGcc = true
+  linuxCCompilerExecutable = "gcc-14"
+  linuxCppCompilerExecutable = "g++-14"
 
   // Add the systemcore compiler
   withCrossSystemCore()

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/ToolchainExtension.java
@@ -41,6 +41,9 @@ public class ToolchainExtension {
     public boolean registerPlatforms = true;
     public boolean registerReleaseBuildType = true;
     public boolean registerDebugBuildType = true;
+    private boolean requireVersionedLinuxGcc = true;
+    private String linuxCCompilerExecutable = "gcc-14";
+    private String linuxCppCompilerExecutable = "g++-14";
     private final ToolchainGraphBuildService rootExtension;
 
     public ToolchainGraphBuildService getToolchainGraphService() {
@@ -152,6 +155,36 @@ public class ToolchainExtension {
 
     public boolean isRemoveInvalidWindowsToolchains() {
         return this.removeInvalidWindowsToolchains;
+    }
+
+    public void setRequireVersionedLinuxGcc(boolean require) {
+        this.requireVersionedLinuxGcc = require;
+    }
+
+    public boolean isRequireVersionedLinuxGcc() {
+        return this.requireVersionedLinuxGcc;
+    }
+
+    public void setLinuxCCompilerExecutable(String executable) {
+        if (executable == null || executable.isBlank()) {
+            throw new IllegalArgumentException("linuxCCompilerExecutable cannot be blank");
+        }
+        this.linuxCCompilerExecutable = executable;
+    }
+
+    public String getLinuxCCompilerExecutable() {
+        return linuxCCompilerExecutable;
+    }
+
+    public void setLinuxCppCompilerExecutable(String executable) {
+        if (executable == null || executable.isBlank()) {
+            throw new IllegalArgumentException("linuxCppCompilerExecutable cannot be blank");
+        }
+        this.linuxCppCompilerExecutable = executable;
+    }
+
+    public String getLinuxCppCompilerExecutable() {
+        return linuxCppCompilerExecutable;
     }
 
     public NamedDomainObjectContainer<ToolchainDescriptorBase> getToolchainDescriptors() {

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/ToolchainRules.java
@@ -38,29 +38,49 @@ import org.gradle.platform.base.PlatformContainer;
 import org.wpilib.toolchain.configurable.CrossCompilerConfiguration;
 
 public class ToolchainRules extends RuleSource {
+    private static final String LINUX_C_COMPILER_EXECUTABLE = "gcc-14";
+    private static final String LINUX_CPP_COMPILER_EXECUTABLE = "g++-14";
+
+    static void configureRequiredLinuxGcc(Gcc gcc) {
+        gcc.eachPlatform(toolchain -> {
+            toolchain.getcCompiler().setExecutable(LINUX_C_COMPILER_EXECUTABLE);
+            toolchain.getCppCompiler().setExecutable(LINUX_CPP_COMPILER_EXECUTABLE);
+            toolchain.getLinker().setExecutable(LINUX_CPP_COMPILER_EXECUTABLE);
+            toolchain.getAssembler().setExecutable(LINUX_C_COMPILER_EXECUTABLE);
+        });
+    }
 
     @Finalize
     void addClangArm(NativeToolChainRegistryInternal toolChainRegistry, ExtensionContainer extContainer) {
         // To work around sometimes GCC and Clang getting picked up on Windows, remove
         // them completely
-        List<Object> toRemove = new ArrayList<>();
+        List<Object> invalidWindowsToolchains = new ArrayList<>();
+        List<Object> linuxFallbackToolchains = new ArrayList<>();
         toolChainRegistry.all(n -> {
             if (OperatingSystem.current().equals(OperatingSystem.WINDOWS)) {
                 if (n instanceof Gcc && n.getName().equals(GccToolChain.DEFAULT_NAME)) {
-                    toRemove.add(n);
+                    invalidWindowsToolchains.add(n);
                 }
                 if (n instanceof Clang && n.getName().equals(ClangToolChain.DEFAULT_NAME)) {
-                    toRemove.add(n);
+                    invalidWindowsToolchains.add(n);
                 }
             }
 
             if (n instanceof Gcc && OperatingSystem.current().equals(OperatingSystem.LINUX)) {
                 Gcc gcc = (Gcc) n;
-                if (NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)
-                        && gcc.getName().equals(GccToolChain.DEFAULT_NAME)) {
-                    gcc.setTargets();
-                    gcc.target(NativePlatforms.desktop);
+                if (gcc.getName().equals(GccToolChain.DEFAULT_NAME)) {
+                    if (NativePlatforms.desktop.equals(NativePlatforms.linuxarm64)) {
+                        gcc.setTargets();
+                        gcc.target(NativePlatforms.desktop);
+                    }
+                    configureRequiredLinuxGcc(gcc);
                 }
+            }
+            // Linux desktop packages are built with Debian Trixie's GCC 14.
+            // Remove default Clang so missing g++-14 cannot silently fall back.
+            if (n instanceof Clang && OperatingSystem.current().equals(OperatingSystem.LINUX)
+                    && n.getName().equals(ClangToolChain.DEFAULT_NAME)) {
+                linuxFallbackToolchains.add(n);
             }
             if (n instanceof Clang && OperatingSystem.current().equals(OperatingSystem.MAC_OS)) {
                 Clang gcc = (Clang) n;
@@ -86,8 +106,11 @@ public class ToolchainRules extends RuleSource {
         });
 
         final ToolchainExtension ext = extContainer.getByType(ToolchainExtension.class);
+        for (var t : linuxFallbackToolchains) {
+            toolChainRegistry.remove(t);
+        }
         if (ext.isRemoveInvalidWindowsToolchains()) {
-            for (var t : toRemove) {
+            for (var t : invalidWindowsToolchains) {
                 toolChainRegistry.remove(t);
             }
         }

--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/ToolchainRules.java
@@ -38,20 +38,18 @@ import org.gradle.platform.base.PlatformContainer;
 import org.wpilib.toolchain.configurable.CrossCompilerConfiguration;
 
 public class ToolchainRules extends RuleSource {
-    private static final String LINUX_C_COMPILER_EXECUTABLE = "gcc-14";
-    private static final String LINUX_CPP_COMPILER_EXECUTABLE = "g++-14";
-
-    static void configureRequiredLinuxGcc(Gcc gcc) {
+    static void configureRequiredLinuxGcc(Gcc gcc, String cCompilerExecutable, String cppCompilerExecutable) {
         gcc.eachPlatform(toolchain -> {
-            toolchain.getcCompiler().setExecutable(LINUX_C_COMPILER_EXECUTABLE);
-            toolchain.getCppCompiler().setExecutable(LINUX_CPP_COMPILER_EXECUTABLE);
-            toolchain.getLinker().setExecutable(LINUX_CPP_COMPILER_EXECUTABLE);
-            toolchain.getAssembler().setExecutable(LINUX_C_COMPILER_EXECUTABLE);
+            toolchain.getcCompiler().setExecutable(cCompilerExecutable);
+            toolchain.getCppCompiler().setExecutable(cppCompilerExecutable);
+            toolchain.getLinker().setExecutable(cppCompilerExecutable);
+            toolchain.getAssembler().setExecutable(cCompilerExecutable);
         });
     }
 
     @Finalize
     void addClangArm(NativeToolChainRegistryInternal toolChainRegistry, ExtensionContainer extContainer) {
+        final ToolchainExtension ext = extContainer.getByType(ToolchainExtension.class);
         // To work around sometimes GCC and Clang getting picked up on Windows, remove
         // them completely
         List<Object> invalidWindowsToolchains = new ArrayList<>();
@@ -73,12 +71,16 @@ public class ToolchainRules extends RuleSource {
                         gcc.setTargets();
                         gcc.target(NativePlatforms.desktop);
                     }
-                    configureRequiredLinuxGcc(gcc);
+                    if (ext.isRequireVersionedLinuxGcc()) {
+                        configureRequiredLinuxGcc(
+                                gcc, ext.getLinuxCCompilerExecutable(), ext.getLinuxCppCompilerExecutable());
+                    }
                 }
             }
-            // Linux desktop packages are built with Debian Trixie's GCC 14.
-            // Remove default Clang so missing g++-14 cannot silently fall back.
-            if (n instanceof Clang && OperatingSystem.current().equals(OperatingSystem.LINUX)
+            // Linux desktop packages are built with a versioned GCC by default.
+            // Remove default Clang so a missing compiler override cannot silently fall back.
+            if (ext.isRequireVersionedLinuxGcc() && n instanceof Clang
+                    && OperatingSystem.current().equals(OperatingSystem.LINUX)
                     && n.getName().equals(ClangToolChain.DEFAULT_NAME)) {
                 linuxFallbackToolchains.add(n);
             }
@@ -105,7 +107,6 @@ public class ToolchainRules extends RuleSource {
             }
         });
 
-        final ToolchainExtension ext = extContainer.getByType(ToolchainExtension.class);
         for (var t : linuxFallbackToolchains) {
             toolChainRegistry.remove(t);
         }

--- a/ToolchainPlugin/src/test/groovy/org/wpilib/toolchain/ToolchainRulesTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/org/wpilib/toolchain/ToolchainRulesTest.groovy
@@ -5,21 +5,78 @@ import org.gradle.nativeplatform.platform.NativePlatform
 import org.gradle.nativeplatform.toolchain.Gcc
 import org.gradle.nativeplatform.toolchain.GccCommandLineToolConfiguration
 import org.gradle.nativeplatform.toolchain.GccPlatformToolChain
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+import spock.lang.TempDir
 import spock.lang.Specification
 
 class ToolchainRulesTest extends Specification {
+  @TempDir File testProjectDir
+  File buildFile
+
+  def setup() {
+    buildFile = new File(testProjectDir, 'build.gradle')
+  }
+
+  def "Versioned Linux GCC requirement can be configured from DSL"() {
+    given:
+    buildFile << """plugins {
+  id 'cpp'
+  id 'org.wpilib.Toolchain'
+}
+
+toolchainsPlugin {
+  requireVersionedLinuxGcc = false
+  linuxCCompilerExecutable = 'gcc-custom'
+  linuxCppCompilerExecutable = 'g++-custom'
+}
+
+tasks.register('verifyLinuxGccSettings') {
+  doLast {
+    assert !toolchainsPlugin.requireVersionedLinuxGcc
+    assert toolchainsPlugin.linuxCCompilerExecutable == 'gcc-custom'
+    assert toolchainsPlugin.linuxCppCompilerExecutable == 'g++-custom'
+  }
+}
+"""
+
+    when:
+    def result = GradleRunner.create()
+                             .withProjectDir(testProjectDir)
+                             .withArguments('verifyLinuxGccSettings', '--stacktrace')
+                             .withPluginClasspath()
+                             .build()
+
+    then:
+    result.task(':verifyLinuxGccSettings').outcome == SUCCESS
+  }
+
   def "Linux default GCC toolchain uses GCC 14 executables"() {
     given:
     def gcc = new RecordingGcc()
 
     when:
-    ToolchainRules.configureRequiredLinuxGcc(gcc)
+    ToolchainRules.configureRequiredLinuxGcc(gcc, 'gcc-14', 'g++-14')
 
     then:
     gcc.platformToolChain.cCompiler.executable == 'gcc-14'
     gcc.platformToolChain.cppCompiler.executable == 'g++-14'
     gcc.platformToolChain.linker.executable == 'g++-14'
     gcc.platformToolChain.assembler.executable == 'gcc-14'
+  }
+
+  def "Linux default GCC toolchain can use custom executables"() {
+    given:
+    def gcc = new RecordingGcc()
+
+    when:
+    ToolchainRules.configureRequiredLinuxGcc(gcc, 'gcc-custom', 'g++-custom')
+
+    then:
+    gcc.platformToolChain.cCompiler.executable == 'gcc-custom'
+    gcc.platformToolChain.cppCompiler.executable == 'g++-custom'
+    gcc.platformToolChain.linker.executable == 'g++-custom'
+    gcc.platformToolChain.assembler.executable == 'gcc-custom'
   }
 
   private static class RecordingGcc implements Gcc {

--- a/ToolchainPlugin/src/test/groovy/org/wpilib/toolchain/ToolchainRulesTest.groovy
+++ b/ToolchainPlugin/src/test/groovy/org/wpilib/toolchain/ToolchainRulesTest.groovy
@@ -1,0 +1,129 @@
+package org.wpilib.toolchain
+
+import org.gradle.api.Action
+import org.gradle.nativeplatform.platform.NativePlatform
+import org.gradle.nativeplatform.toolchain.Gcc
+import org.gradle.nativeplatform.toolchain.GccCommandLineToolConfiguration
+import org.gradle.nativeplatform.toolchain.GccPlatformToolChain
+import spock.lang.Specification
+
+class ToolchainRulesTest extends Specification {
+  def "Linux default GCC toolchain uses GCC 14 executables"() {
+    given:
+    def gcc = new RecordingGcc()
+
+    when:
+    ToolchainRules.configureRequiredLinuxGcc(gcc)
+
+    then:
+    gcc.platformToolChain.cCompiler.executable == 'gcc-14'
+    gcc.platformToolChain.cppCompiler.executable == 'g++-14'
+    gcc.platformToolChain.linker.executable == 'g++-14'
+    gcc.platformToolChain.assembler.executable == 'gcc-14'
+  }
+
+  private static class RecordingGcc implements Gcc {
+    final RecordingPlatformToolChain platformToolChain = new RecordingPlatformToolChain()
+
+    @Override
+    List<File> getPath() {
+      return []
+    }
+
+    @Override
+    void path(Object... paths) {}
+
+    @Override
+    void target(String targetPlatform) {}
+
+    @Override
+    void target(String targetPlatform, Action<? super GccPlatformToolChain> action) {
+      action.execute(platformToolChain)
+    }
+
+    @Override
+    void setTargets(String... targets) {}
+
+    @Override
+    void eachPlatform(Action<? super GccPlatformToolChain> action) {
+      action.execute(platformToolChain)
+    }
+
+    @Override
+    String getName() {
+      return 'gcc'
+    }
+
+    @Override
+    String getDisplayName() {
+      return 'gcc'
+    }
+  }
+
+  private static class RecordingPlatformToolChain implements GccPlatformToolChain {
+    final RecordingTool cCompiler = new RecordingTool()
+    final RecordingTool cppCompiler = new RecordingTool()
+    final RecordingTool objcCompiler = new RecordingTool()
+    final RecordingTool objcppCompiler = new RecordingTool()
+    final RecordingTool assembler = new RecordingTool()
+    final RecordingTool linker = new RecordingTool()
+    final RecordingTool staticLibArchiver = new RecordingTool()
+
+    @Override
+    NativePlatform getPlatform() {
+      return null
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getcCompiler() {
+      return cCompiler
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getCppCompiler() {
+      return cppCompiler
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getObjcCompiler() {
+      return objcCompiler
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getObjcppCompiler() {
+      return objcppCompiler
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getAssembler() {
+      return assembler
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getLinker() {
+      return linker
+    }
+
+    @Override
+    GccCommandLineToolConfiguration getStaticLibArchiver() {
+      return staticLibArchiver
+    }
+  }
+
+  private static class RecordingTool implements GccCommandLineToolConfiguration {
+    String executable
+
+    @Override
+    String getExecutable() {
+      return executable
+    }
+
+    @Override
+    void setExecutable(String executable) {
+      this.executable = executable
+    }
+
+    @Override
+    void withArguments(Action<? super List<String>> action) {}
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "org.wpilib"
-    version = "2027.12.0"
+    version = "2027.13.0"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
+++ b/src/main/java/org/wpilib/nativeutils/NativeUtilsExtension.java
@@ -413,4 +413,28 @@ public class NativeUtilsExtension {
   public boolean isRemoveInvalidWindowsToolchains() {
       return tcExt.isRemoveInvalidWindowsToolchains();
   }
+
+  public void setRequireVersionedLinuxGcc(boolean require) {
+    tcExt.setRequireVersionedLinuxGcc(require);
+  }
+
+  public boolean isRequireVersionedLinuxGcc() {
+    return tcExt.isRequireVersionedLinuxGcc();
+  }
+
+  public void setLinuxCCompilerExecutable(String executable) {
+    tcExt.setLinuxCCompilerExecutable(executable);
+  }
+
+  public String getLinuxCCompilerExecutable() {
+    return tcExt.getLinuxCCompilerExecutable();
+  }
+
+  public void setLinuxCppCompilerExecutable(String executable) {
+    tcExt.setLinuxCppCompilerExecutable(executable);
+  }
+
+  public String getLinuxCppCompilerExecutable() {
+    return tcExt.getLinuxCppCompilerExecutable();
+  }
 }

--- a/src/test/groovy/org/wpilib/nativeutils/NativeUtilsToolchainSettingsTest.groovy
+++ b/src/test/groovy/org/wpilib/nativeutils/NativeUtilsToolchainSettingsTest.groovy
@@ -1,0 +1,48 @@
+package org.wpilib.nativeutils
+
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+import spock.lang.TempDir
+import spock.lang.Specification
+
+class NativeUtilsToolchainSettingsTest extends Specification {
+  @TempDir File testProjectDir
+  File buildFile
+
+  def setup() {
+    buildFile = new File(testProjectDir, 'build.gradle')
+  }
+
+  def "Versioned Linux GCC requirement can be configured from NativeUtils DSL"() {
+    given:
+    buildFile << """plugins {
+  id 'cpp'
+  id 'org.wpilib.NativeUtils'
+}
+
+nativeUtils {
+  requireVersionedLinuxGcc = false
+  linuxCCompilerExecutable = 'gcc-custom'
+  linuxCppCompilerExecutable = 'g++-custom'
+}
+
+tasks.register('verifyLinuxGccSettings') {
+  doLast {
+    assert !nativeUtils.requireVersionedLinuxGcc
+    assert nativeUtils.linuxCCompilerExecutable == 'gcc-custom'
+    assert nativeUtils.linuxCppCompilerExecutable == 'g++-custom'
+  }
+}
+"""
+
+    when:
+    def result = GradleRunner.create()
+                             .withProjectDir(testProjectDir)
+                             .withArguments('verifyLinuxGccSettings', '--stacktrace')
+                             .withPluginClasspath()
+                             .build()
+
+    then:
+    result.task(':verifyLinuxGccSettings').outcome == SUCCESS
+  }
+}

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -3,7 +3,7 @@ import org.wpilib.nativeutils.vendordeps.WPIVendorDepsPlugin
 
 plugins {
     id "cpp"
-    id "org.wpilib.NativeUtils" version "2027.12.0"
+    id "org.wpilib.NativeUtils" version "2027.13.0"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
There are ABI breaks between GCC 14 and 16 (e.g. std::format), and our distributed binaries are built with 14 (Debian Trixie), so to avoid breaks on systems with newer compiler versions installed, require GCC 14 specifically.