### PR TITLE
Revert "Update gradle to 9.4.1 (#294)"

### DIFF
--- a/ToolchainPlugin/src/main/java/org/wpilib/toolchain/InstallToolchainTask.java
+++ b/ToolchainPlugin/src/main/java/org/wpilib/toolchain/InstallToolchainTask.java
@@ -5,12 +5,10 @@ import javax.inject.Inject;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.os.OperatingSystem;
 
-@CacheableTask
 public class InstallToolchainTask extends DefaultTask {
 
     private ToolchainDescriptorBase desc;

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ java {
 
 allprojects {
     group = "org.wpilib"
-    version = "2027.13.0"
+    version = "2027.13.1"
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,6 @@ tasks.register('PatchExamples') {
 jar.finalizedBy PatchExamples
 
 wrapper {
-    gradleVersion = '9.4.1'
+    gradleVersion = '9.2.0'
     distributionType = Wrapper.DistributionType.BIN
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/org/wpilib/nativeutils/UnzipTransform.java
+++ b/src/main/java/org/wpilib/nativeutils/UnzipTransform.java
@@ -5,9 +5,7 @@ import org.gradle.api.artifacts.transform.TransformAction;
 import org.gradle.api.artifacts.transform.TransformOutputs;
 import org.gradle.api.artifacts.transform.TransformParameters;
 import org.gradle.api.file.FileSystemLocation;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.PathSensitive;
 import org.gradle.internal.UncheckedException;
 
 import java.io.BufferedInputStream;
@@ -28,7 +26,6 @@ public interface UnzipTransform extends TransformAction<TransformParameters.None
     // TODO see if we can get incremental to work
 
     @InputArtifact
-    @PathSensitive(PathSensitivity.RELATIVE)
     Provider<FileSystemLocation> getZippedFile();
 
     @Override

--- a/src/main/java/org/wpilib/nativeutils/exports/ExportsGenerationTask.java
+++ b/src/main/java/org/wpilib/nativeutils/exports/ExportsGenerationTask.java
@@ -15,30 +15,25 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 import org.gradle.process.ExecSpec;
 
 import groovy.lang.Closure;
 
-@CacheableTask
 public abstract class ExportsGenerationTask extends DefaultTask implements Action<ExecSpec> {
 
     @InputFiles
-    @PathSensitive(org.gradle.api.tasks.PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getSourceFiles();
 
     @OutputFile
     public abstract RegularFileProperty getDefFile();
 
     @InputFile
-    @PathSensitive(org.gradle.api.tasks.PathSensitivity.RELATIVE)
     public abstract RegularFileProperty getDefFileGenerator();
 
     @Internal

--- a/src/main/java/org/wpilib/nativeutils/exports/ExtractDefFileGeneratorTask.java
+++ b/src/main/java/org/wpilib/nativeutils/exports/ExtractDefFileGeneratorTask.java
@@ -10,14 +10,12 @@ import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.process.ExecOperations;
 
 import org.wpilib.toolchain.NativePlatforms;
 
-@CacheableTask
 public abstract class ExtractDefFileGeneratorTask extends DefaultTask {
 
   @OutputFile

--- a/src/main/java/org/wpilib/nativeutils/exports/PrivateExportsGenerationTask.java
+++ b/src/main/java/org/wpilib/nativeutils/exports/PrivateExportsGenerationTask.java
@@ -10,20 +10,15 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
-@CacheableTask
 public abstract class PrivateExportsGenerationTask extends DefaultTask {
 
   @InputFile
-  @PathSensitive(PathSensitivity.RELATIVE)
   public abstract RegularFileProperty getSymbolsToExportFile();
 
   @OutputFile

--- a/src/main/java/org/wpilib/nativeutils/resources/ResourceGenerationTask.java
+++ b/src/main/java/org/wpilib/nativeutils/resources/ResourceGenerationTask.java
@@ -16,7 +16,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.IgnoreEmptyDirectories;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
@@ -31,7 +30,6 @@ import org.gradle.work.InputChanges;
 import org.gradle.workers.WorkQueue;
 import org.gradle.workers.WorkerExecutor;
 
-@CacheableTask
 public abstract class ResourceGenerationTask extends DefaultTask {
     private final ConfigurableFileCollection sourceFiles = getProject().getObjects().fileCollection();
 

--- a/src/main/java/org/wpilib/nativeutils/sourcelink/LinkerSourceLinkGenerationTask.java
+++ b/src/main/java/org/wpilib/nativeutils/sourcelink/LinkerSourceLinkGenerationTask.java
@@ -25,20 +25,15 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.PathSensitive;
-import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 
-@CacheableTask
 public class LinkerSourceLinkGenerationTask extends DefaultTask {
     private final ListProperty<File> inputFiles;
     private final RegularFileProperty sourceLinkFile;
 
     @InputFiles
-    @PathSensitive(PathSensitivity.RELATIVE)
     public ListProperty<File> getInputFiles() {
         return inputFiles;
     }

--- a/src/main/java/org/wpilib/nativeutils/sourcelink/SourceLinkGenerationTask.java
+++ b/src/main/java/org/wpilib/nativeutils/sourcelink/SourceLinkGenerationTask.java
@@ -31,12 +31,10 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.MapProperty;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
-@CacheableTask
 public class SourceLinkGenerationTask extends DefaultTask {
 
     private final RegularFileProperty sourceLinkFile;

--- a/src/main/java/org/wpilib/nativeutils/tasks/PrintNativeDependenciesTask.java
+++ b/src/main/java/org/wpilib/nativeutils/tasks/PrintNativeDependenciesTask.java
@@ -4,13 +4,11 @@ import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.NamedDomainObjectSet;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import org.wpilib.nativeutils.NativeUtilsExtension;
 //import org.wpilib.nativeutils.NativeUtilsExtension.NamedNativeDependencyList;
 
-@CacheableTask
 public class PrintNativeDependenciesTask extends DefaultTask {
 
     @Inject

--- a/src/main/java/org/wpilib/nativeutils/vendordeps/VendorDepTask.java
+++ b/src/main/java/org/wpilib/nativeutils/vendordeps/VendorDepTask.java
@@ -10,7 +10,6 @@ import java.util.concurrent.ExecutionException;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.Directory;
-import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -23,7 +22,6 @@ import org.wpilib.nativeutils.vendordeps.WPIVendorDepsExtension.JsonDependency;
 /**
  * A task type for downloading vendordep JSON files from the vendor URL.
  */
-@CacheableTask
 public class VendorDepTask extends DefaultTask {
     private String url;
     private boolean update;

--- a/testing/cpp/build.gradle
+++ b/testing/cpp/build.gradle
@@ -3,7 +3,7 @@ import org.wpilib.nativeutils.vendordeps.WPIVendorDepsPlugin
 
 plugins {
     id "cpp"
-    id "org.wpilib.NativeUtils" version "2027.13.0"
+    id "org.wpilib.NativeUtils" version "2027.13.1"
 }
 
 nativeUtils.addWpiNativeUtils()


### PR DESCRIPTION
This also made linker scripts cacheable, which broke the allwpilib build.